### PR TITLE
Add explict bash to test.sh to make it working on a multiple system / shell

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo $1
 
 WASM_BUILD_RUSTFLAGS='-C link-arg=-s' cargo build --manifest-path=contracts/$1/Cargo.toml --release --target wasm32-unknown-unknown &&


### PR DESCRIPTION
*rationale*: the `test.sh`didn't work on my machine (macOS + fish) without the explicit shell definition.