### PR TITLE
Improve WASM generated size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,35 @@
-test: wasm_target hello factorial
-	cargo test
+REPO_NAME  := $(shell git config --get-regexp remote.origin.url | sed "s/.*dusk-network\/\(.*\)\.git/\1/")
+PACKAGE_NAME := $(shell cargo metadata --no-deps --format-version=1 | python -c "import sys, json; print json.load(sys.stdin)['packages'][0]['name']")
+REPO_BADGE_URL := "https://img.shields.io/badge/github-$(shell echo $(REPO_NAME) | sed "s/-/--/g")-brightgreen?logo=github"
+META := "<meta http-equiv=refresh content=0;url=./$(shell echo $(PACKAGE_NAME) | sed "s/-/_/g")/index.html>"
 
-wasm_target:
-	rustup target add wasm32-unknown-unknown
+define generate_docs 
+	@echo $(META) > target/doc/index.html && \
+	curl -o 'target/doc/badge.svg' 'https://img.shields.io/badge/docs-latest-blue?logo=rust' && \
+	curl -o 'target/doc/repo-badge.svg' $(REPO_BADGE_URL) && \
+	curl -L https://github.com/davisp/ghp-import/archive/master.tar.gz | tar --strip-components 1 -C $1 -xz
+	$1/ghp_import.py -n target/doc
+	rm -rf $1
+endef
 
-hello: tests/contracts/hello/wasm/src/lib.rs
-	WASM_BUILD_RUSTFLAGS='-C link-arg=-s' cargo build --manifest-path=tests/contracts/$@/wasm/Cargo.toml --release --target wasm32-unknown-unknown
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-factorial: tests/contracts/factorial/wasm/src/lib.rs
-	WASM_BUILD_RUSTFLAGS='-C link-arg=-s' cargo build --manifest-path=tests/contracts/$@/wasm/Cargo.toml --release --target wasm32-unknown-unknown
+doc: ## Generate documentation
+	@cargo rustdoc --lib
+
+doc-internal: ## Generate documentation with private items
+	@cargo rustdoc --lib -- --document-private-items
+
+publish-doc: ## Publish the documentation as github pages
+	@$(call generate_docs, $(shell mktemp -d)) && \
+	git push -f https://github.com/dusk-network/$(REPO_NAME) gh-pages
+
+wasm: ## Generate the WASM for the contract given (e.g. make wasm for=transfer)
+	@cargo rustc \
+		--manifest-path=tests/contracts/$(for)/wasm/Cargo.toml \
+		--release \
+		--target wasm32-unknown-unknown \
+		-- -C link-args=-s
+
+.PHONY: help doc doc-internal publish-doc wasm

--- a/tests/contracts/add/wasm/Cargo.toml
+++ b/tests/contracts/add/wasm/Cargo.toml
@@ -10,3 +10,7 @@ edition = "2018"
 [dependencies]
  dusk-abi = { path = "../../../../dusk-abi", default-features = false }
  serde = { version = "*", default-features = false, features = ["derive"] }
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/tests/contracts/default_account/wasm/Cargo.toml
+++ b/tests/contracts/default_account/wasm/Cargo.toml
@@ -10,3 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 dusk-abi = { path = "../../../../dusk-abi", default-features = false }
 serde = { version = "*", default-features = false, features = ["derive"] }
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/tests/contracts/factorial/wasm/Cargo.toml
+++ b/tests/contracts/factorial/wasm/Cargo.toml
@@ -10,3 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 dusk-abi = { path = "../../../../dusk-abi", default-features = false }
 serde = { version = "*", default-features = false, features = ["derive"] }
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/tests/contracts/hello/wasm/Cargo.toml
+++ b/tests/contracts/hello/wasm/Cargo.toml
@@ -9,3 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 dusk-abi = { path = "../../../../dusk-abi", default-features = false }
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/tests/contracts/panic/wasm/Cargo.toml
+++ b/tests/contracts/panic/wasm/Cargo.toml
@@ -9,3 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 dusk-abi = { path = "../../../../dusk-abi", default-features = false }
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
The fix is passing `-C link-args=-s` as flag to the compiler.
The current attempt was setting `WASM_BUILD_RUSTFLAGS` but this is a
custom environment var of parity that has no effect whatsoever in
a default environment.

Now we call directly `cargo rustc` in the Makefile, with all parameters
needed.
I also add few optimization in the contract's Cargo.toml (`lto` and
`codegen-units`) to skimmer other few KBs.

For `transfer` contract we went from ~680KB to 16KB (`-C link-args=-s`)
to 14KB (`lto` / `codegen-units`).

We still need to strip down the panicking infrastructure.

Resolves: #34, #35
See also: #36