### PR TITLE
Refactor the Transfer Contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,16 @@ serde = "1.0"
 kelvin = "0.9"
 kelvin-radix = "0.5"
 fermion = "0.2"
-
-phoenix = { path = "../phoenix" }
-phoenix-abi = { path = "../phoenix-abi" }
-dusk-abi = { path = "./dusk-abi" }
 lazy_static = "1.4"
 parking_lot = "0.10"
+
+dusk-abi = { path = "./dusk-abi" }
+phoenix = { git = "ssh://git@github.com/dusk-network/phoenix.git" }
+phoenix-abi = { git = "ssh://git@github.com/dusk-network/phoenix-abi.git" }
+
+# UNCOMMENT for local development
+# phoenix-abi = { path="../phoenix-abi" }
+# phoenix = { path="../phoenix" }
 
 [dev-dependencies]
 tempfile = "*"
@@ -33,5 +37,6 @@ factorial = { path = "tests/contracts/factorial/wasm" }
 transfer = { path = "tests/contracts/transfer/wasm" }
 
 [[bench]]
+sample_size = 10
 name = "factorial"
 harness = false

--- a/dusk-abi/src/lib.rs
+++ b/dusk-abi/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(lang_items)]
 #![feature(panic_info_message)]
 
+use serde::de::DeserializeOwned;
 pub use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "std"))]
@@ -157,6 +158,18 @@ where
 {
     unsafe { external::call_data(buffer) }
     encoding::decode(buffer).unwrap()
+}
+
+/// Returns the arguments the contract was called with.
+/// It's a helper function that wraps `call_data` handling the buffer for
+/// deserialization internally
+pub fn args<T>() -> T
+where
+    T: DeserializeOwned,
+{
+    let mut buffer = [0u8; CALL_DATA_SIZE];
+    unsafe { external::call_data(&mut buffer) }
+    encoding::decode(&buffer).unwrap()
 }
 
 /// Verifies an ed25519_signature, returns true if successful

--- a/src/call_context.rs
+++ b/src/call_context.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::time::Instant;
 
 use dusk_abi::{CALL_DATA_SIZE, H256};
 use kelvin::{ByteHash, ValRef, ValRefMut};
@@ -104,6 +105,7 @@ impl<'a, S: Resolver<H>, H: ByteHash> CallContext<'a, S, H> {
             }
         }
 
+        let start = Instant::now();
         match instance.invoke_export("call", &[], self) {
             Err(wasmi::Error::Trap(trap)) => {
                 if let TrapKind::Host(t) = trap.kind() {
@@ -123,6 +125,8 @@ impl<'a, S: Resolver<H>, H: ByteHash> CallContext<'a, S, H> {
             Err(e) => return Err(e.into()),
             Ok(_) => (),
         }
+
+        println!("Contract's call took {:?}", start.elapsed());
 
         // return the call_data (now containing return value)
         Ok(self.stack.pop().expect("Invalid stack").into_call_data())

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,12 +1,12 @@
 use std::io;
 use std::rc::Rc;
+use std::time::Instant;
 
 use failure::{bail, err_msg, Error};
 use kelvin::{ByteHash, Content, Sink, Source};
 use parity_wasm::elements::{
     self, InitExpr, Instruction, Internal, Serialize, Type, ValueType,
 };
-use pwasm_utils;
 use pwasm_utils::rules;
 use wasmi::Module as WasmiModule;
 
@@ -54,10 +54,13 @@ impl MeteredContract {
             if let MeteredContract::Code(code) =
                 mem::replace(self, MeteredContract::Code(vec![]))
             {
+                let start = Instant::now();
                 *self = MeteredContract::Module {
                     module: Rc::new(wasmi::Module::from_buffer(&code)?),
                     code,
                 };
+
+                println!("Compiled Contract in {:?}", start.elapsed());
             }
         }
         Ok(())

--- a/src/ops/phoenix_ops.rs
+++ b/src/ops/phoenix_ops.rs
@@ -5,16 +5,10 @@ use crate::VMError;
 use dusk_abi::encoding;
 use kelvin::ByteHash;
 use phoenix::{db, Transaction, TransactionItem};
-use phoenix_abi::{
-    types::{
-        MAX_NOTES_PER_TRANSACTION, MAX_NULLIFIERS_PER_TRANSACTION, NOTE_SIZE,
-        NULLIFIER_SIZE,
-    },
-    Note, Nullifier,
-};
+use phoenix_abi::{Note, Nullifier};
 use wasmi::{RuntimeArgs, RuntimeValue, ValueType};
 
-pub const DB_PATH: &'static str = "/tmp/rusk-vm-demo";
+pub const DB_PATH: &str = "/tmp/rusk-vm-demo";
 
 pub struct PhoenixStore;
 
@@ -35,14 +29,12 @@ impl<S: Resolver<H>, H: ByteHash> AbiCall<S, H> for PhoenixStore {
             .with_direct_access_mut::<Result<Option<RuntimeValue>, VMError>, _>(
                 |a| {
                     let nullifiers_buf = &a[nullifiers_ptr
-                        ..nullifiers_ptr
-                            + (MAX_NULLIFIERS_PER_TRANSACTION
-                                * NULLIFIER_SIZE)];
+                        ..nullifiers_ptr + (Nullifier::MAX * Nullifier::SIZE)];
                     let nullifiers: Result<
                         Vec<TransactionItem>,
                         fermion::Error,
                     > = nullifiers_buf
-                        .chunks(NULLIFIER_SIZE)
+                        .chunks(Nullifier::SIZE)
                         .map(|bytes| {
                             let nullifier: Nullifier = encoding::decode(bytes)?;
                             let mut item = TransactionItem::default();
@@ -52,12 +44,12 @@ impl<S: Resolver<H>, H: ByteHash> AbiCall<S, H> for PhoenixStore {
                         .collect();
                     let mut nullifiers = nullifiers.unwrap();
 
-                    let notes_buf = &a[notes_ptr
-                        ..notes_ptr + (MAX_NOTES_PER_TRANSACTION * NOTE_SIZE)];
+                    let notes_buf =
+                        &a[notes_ptr..notes_ptr + (Note::MAX * Note::SIZE)];
 
                     let notes: Result<Vec<TransactionItem>, fermion::Error> =
                         notes_buf
-                            .chunks(NOTE_SIZE)
+                            .chunks(Note::SIZE)
                             .map(|bytes| {
                                 let note: Note = encoding::decode(bytes)?;
                                 Ok(TransactionItem::from(note))
@@ -101,14 +93,12 @@ impl<S: Resolver<H>, H: ByteHash> AbiCall<S, H> for PhoenixVerify {
             .with_direct_access_mut::<Result<Option<RuntimeValue>, VMError>, _>(
                 |a| {
                     let nullifiers_buf = &a[nullifiers_ptr
-                        ..nullifiers_ptr
-                            + (MAX_NULLIFIERS_PER_TRANSACTION
-                                * NULLIFIER_SIZE)];
+                        ..nullifiers_ptr + (Nullifier::MAX * Nullifier::SIZE)];
                     let nullifiers: Result<
                         Vec<TransactionItem>,
                         fermion::Error,
                     > = nullifiers_buf
-                        .chunks(NULLIFIER_SIZE)
+                        .chunks(Nullifier::SIZE)
                         .map(|bytes| {
                             let nullifier: Nullifier = encoding::decode(bytes)?;
                             let mut item = TransactionItem::default();
@@ -118,12 +108,12 @@ impl<S: Resolver<H>, H: ByteHash> AbiCall<S, H> for PhoenixVerify {
                         .collect();
                     let mut nullifiers = nullifiers.unwrap();
 
-                    let notes_buf = &a[notes_ptr
-                        ..notes_ptr + (MAX_NOTES_PER_TRANSACTION * NOTE_SIZE)];
+                    let notes_buf =
+                        &a[notes_ptr..notes_ptr + (Note::MAX * Note::SIZE)];
 
                     let notes: Result<Vec<TransactionItem>, fermion::Error> =
                         notes_buf
-                            .chunks(NOTE_SIZE)
+                            .chunks(Note::SIZE)
                             .map(|bytes| {
                                 let note: Note = encoding::decode(bytes)?;
                                 Ok(TransactionItem::from(note))

--- a/tests/contracts/transfer/wasm/Cargo.toml
+++ b/tests/contracts/transfer/wasm/Cargo.toml
@@ -11,3 +11,7 @@ crate-type = ["cdylib", "rlib"]
 dusk-abi = { path = "../../../../dusk-abi", default-features = false }
 phoenix-abi = { path = "../../../../../phoenix-abi", default-features = false }
 serde = { version = "*", default-features = false, features = ["derive"] }
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/tests/contracts/transfer/wasm/src/lib.rs
+++ b/tests/contracts/transfer/wasm/src/lib.rs
@@ -1,38 +1,22 @@
 #![no_std]
-use dusk_abi::{self, encoding, ContractCall, CALL_DATA_SIZE};
-use phoenix_abi::{
-    types::{
-        MAX_NOTES_PER_TRANSACTION, MAX_NULLIFIERS_PER_TRANSACTION, NOTE_SIZE,
-        NULLIFIER_SIZE,
-    },
-    Note, Nullifier,
-};
+use dusk_abi::{self, ContractCall};
+use phoenix_abi::{Note, Nullifier};
 
 // Interface
 pub fn transfer(
-    nullifiers: [Nullifier; MAX_NULLIFIERS_PER_TRANSACTION],
-    notes: [Note; MAX_NOTES_PER_TRANSACTION],
+    nullifiers: [Nullifier; Nullifier::MAX],
+    notes: [Note; Note::MAX],
 ) -> ContractCall<bool> {
     ContractCall::new((nullifiers, notes)).unwrap()
 }
 
+#[no_mangle]
 pub fn call() {
-    let mut buffer = [0u8; CALL_DATA_SIZE];
-    let (nullifiers, notes): (
-        [Nullifier; MAX_NULLIFIERS_PER_TRANSACTION],
-        [Note; MAX_NOTES_PER_TRANSACTION],
-    ) = dusk_abi::call_data(&mut buffer);
+    let (nullifiers, notes): ([Nullifier; Nullifier::MAX], [Note; Note::MAX]) =
+        dusk_abi::args();
 
-    let mut nullifiers_buf =
-        [0u8; MAX_NULLIFIERS_PER_TRANSACTION * NULLIFIER_SIZE];
-    encoding::encode(&nullifiers, &mut nullifiers_buf)
-        .expect("buffer insufficient");
-    let mut notes_buf = [0u8; MAX_NOTES_PER_TRANSACTION * NOTE_SIZE];
-    encoding::encode(&notes, &mut notes_buf).expect("buffer insufficient");
-
-    if !phoenix_abi::verify(&nullifiers_buf, &notes_buf) {
+    if !phoenix_abi::verify(&nullifiers, &notes) {
         dusk_abi::ret(0);
     }
-
-    dusk_abi::ret(phoenix_abi::store(&nullifiers_buf, &notes_buf));
+    dusk_abi::ret(phoenix_abi::store(&nullifiers, &notes));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,10 +5,7 @@ use kelvin::Blake2b;
 use std::fs;
 
 use dusk_abi::ContractCall;
-use phoenix_abi::{
-    types::{MAX_NOTES_PER_TRANSACTION, MAX_NULLIFIERS_PER_TRANSACTION},
-    Note, Nullifier,
-};
+use phoenix_abi::{Note, Nullifier};
 use rusk_vm::{Contract, GasMeter, NetworkState, Schedule, StandardABI};
 
 #[test]
@@ -77,20 +74,24 @@ fn transfer() {
     let mut gas = GasMeter::with_limit(1_000_000_000);
 
     // Generate some items
-    let nullifiers = [Nullifier::default(); MAX_NULLIFIERS_PER_TRANSACTION];
-    let notes = [Note::default(); MAX_NOTES_PER_TRANSACTION];
+    let nullifiers = [Nullifier::default(); Nullifier::MAX];
+    let notes = [Note::default(); Note::MAX];
 
     let succeeded = network
         .call_contract(&contract_id, transfer(nullifiers, notes), &mut gas)
         .unwrap();
 
-    if !succeeded {
-        panic!("contract execution failed");
+    // TODO: change condition once Transfer Contract properly implemented
+    assert!(
+        !succeeded,
+        "Transfer Contract called. 
+         Expected to returns `false` until proper implementation."
+    );
+    if (succeeded) {
+        // Ensure data was written
+        fs::metadata("/tmp/rusk-vm-demo/data").unwrap();
+
+        // Clean up
+        fs::remove_dir_all("/tmp/rusk-vm-demo").unwrap();
     }
-
-    // Ensure data was written
-    fs::metadata("/tmp/rusk-vm-demo/data").unwrap();
-
-    // Clean up
-    fs::remove_dir_all("/tmp/rusk-vm-demo").unwrap();
 }


### PR DESCRIPTION
- Add `dusk_abi::args()` with owned buffer to reduce boilerplate
- Add elapsed time when a contract is compiled and called
- Use the refactored `phoenix-abi`
- Add back `#[no_mangle]` for the Transfer Contract (it fails to find
  the function called `call` for contracts otherwise)
- Rewrite the Transfer contract to have less boilerplate code
- Rewrite the Transfer Unit Test (WIP, now expects to fail)

See Also: dusk-network/phoenix-abi#15