### PR TITLE
Add CorrectnessCircuit to the verify_proof ABICall map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,19 @@ canonical_host = "0.5"
 canonical_derive = "0.5"
 dusk-kelvin-map = "0.3"
 dusk-plonk = "0.5"
-rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "rusk-profile-0.1.0"}
-transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-circuits-0.1.0"}
+rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0"}
+transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0"}
+bid-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0"}
 anyhow = {version = "1.0", optional = true}
 rand = "0.7"
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.17.0"}
+dusk-poseidon = "0.18"
 dusk-bls12_381 = "0.6"
 dusk-bytes = "0.1"
 bincode = "1.0"
 
 [dev-dependencies]
 rand = "0.7"
-transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-circuits-0.1.0", features = ["builder", "builder-no-rusk-profile-keys"]}
+transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0", features = ["builder", "builder-no-rusk-profile-keys"]}
 # test contracts
 counter = { path = "tests/contracts/counter", features = ["host"] }
 fibonacci = { path = "tests/contracts/fibonacci", features = ["host"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ canonical_host = "0.5"
 canonical_derive = "0.5"
 dusk-kelvin-map = "0.3"
 dusk-plonk = "0.5"
-rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "rusk-profile-0.2.0"}
+rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "rusk-profile-0.3.0"}
 transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-circuits-0.1.1"}
 bid-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "bid-circuits-0.1.0"}
 anyhow = {version = "1.0", optional = true}
@@ -37,6 +37,7 @@ delegator = { path = "tests/contracts/delegator", features = ["host"] }
 stack = { path = "tests/contracts/stack", features = ["host"] }
 hash = { path = "tests/contracts/hash", features = ["host"] }
 verify_proof = { path = "tests/contracts/verify_proof", features = ["host"] }
+rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "rusk-profile-0.3.0"}
 
 [[bench]]
 name = "factorial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-vm"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 
@@ -11,7 +11,7 @@ parity-wasm = "0.41"
 pwasm-utils = "0.12.0"
 failure = "0.1"
 
-dusk-abi = { path = "dusk-abi", version = "0.3" }
+dusk-abi = { path = "dusk-abi", version = "0.4" }
 canonical = { version = "0.5" , features = ["host"] }
 canonical_host = "0.5"
 canonical_derive = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ canonical_host = "0.5"
 canonical_derive = "0.5"
 dusk-kelvin-map = "0.3"
 dusk-plonk = "0.5"
-rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0"}
-transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0"}
-bid-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0"}
+rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "rusk-profile-0.2.0"}
+transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-circuits-0.1.1"}
+bid-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "bid-circuits-0.1.0"}
 anyhow = {version = "1.0", optional = true}
 rand = "0.7"
 dusk-poseidon = "0.18"
@@ -29,7 +29,7 @@ bincode = "1.0"
 
 [dev-dependencies]
 rand = "0.7"
-transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-contract-0.3.0", features = ["builder", "builder-no-rusk-profile-keys"]}
+transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-circuits-0.1.1", features = ["builder", "builder-no-rusk-profile-keys"]}
 # test contracts
 counter = { path = "tests/contracts/counter", features = ["host"] }
 fibonacci = { path = "tests/contracts/fibonacci", features = ["host"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,3 @@ rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "rusk-profi
 [[bench]]
 name = "factorial"
 harness = false
-

--- a/dusk-abi/Cargo.toml
+++ b/dusk-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-abi"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 

--- a/dusk-abi/Cargo.toml
+++ b/dusk-abi/Cargo.toml
@@ -9,7 +9,7 @@ canonical = "0.5"
 canonical_derive = "0.5"
 wee_alloc = "0.4"
 
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.17.0", default-features = false}
+dusk-poseidon = {version = "0.18", default-features = false}
 dusk-bls12_381 = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
 

--- a/dusk-abi/src/lib.rs
+++ b/dusk-abi/src/lib.rs
@@ -273,7 +273,11 @@ pub fn verify_proof(
             label_len as i32,
         )
     };
-    true
+
+    if res == 1 {
+        return true;
+    }
+    false
 }
 
 /// Call another contract at address `target`

--- a/src/ops/poseidon_hash.rs
+++ b/src/ops/poseidon_hash.rs
@@ -13,7 +13,7 @@ use wasmi::{RuntimeArgs, RuntimeValue, ValueType};
 
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
-use poseidon252::sponge::hash;
+use dusk_poseidon::sponge::hash;
 
 pub struct PoseidonHash;
 

--- a/src/ops/verify_proof.rs
+++ b/src/ops/verify_proof.rs
@@ -8,6 +8,7 @@ use super::AbiCall;
 use crate::call_context::{CallContext, Resolver};
 use crate::VMError;
 
+use bid_circuits::CorrectnessCircuit;
 use canonical::Store;
 use dusk_plonk::prelude::*;
 use transfer_circuits::{
@@ -113,21 +114,22 @@ fn select_and_verify<'a, S: Store>(
     proof: &Proof,
 ) -> bool {
     match label.as_str() {
-        "transfer-execute-1-0" => verify_proof(ExecuteCircuit::<17, 15>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 1,0).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-1-1" => verify_proof(ExecuteCircuit::<17, 15>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 1,1).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-1-2" => verify_proof(ExecuteCircuit::<17, 15>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 1,2).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-2-0" => verify_proof(ExecuteCircuit::<17, 16>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 2,0).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-2-1" => verify_proof(ExecuteCircuit::<17, 16>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 2,1).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-2-2" => verify_proof(ExecuteCircuit::<17, 16>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 2,2).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-3-0" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 3,0).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-3-1" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 3,1).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-3-2" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 3,2).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-4-0" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 4,0).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-4-1" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 4,1).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
-        "transfer-execute-4-2" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 4,2).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-1-0" => verify_proof(ExecuteCircuit::<17, 15>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 1,0, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-1-1" => verify_proof(ExecuteCircuit::<17, 15>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 1,1, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-1-2" => verify_proof(ExecuteCircuit::<17, 15>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 1,2, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-2-0" => verify_proof(ExecuteCircuit::<17, 16>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 2,0, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-2-1" => verify_proof(ExecuteCircuit::<17, 16>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 2,1, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-2-2" => verify_proof(ExecuteCircuit::<17, 16>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 2,2, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-3-0" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 3,0, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-3-1" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 3,1, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-3-2" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 3,2, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-4-0" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 4,0, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-4-1" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 4,1, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
+        "transfer-execute-4-2" => verify_proof(ExecuteCircuit::<17, 17>::create_dummy_circuit::<_,S>(&mut rand::thread_rng(), 4,2, true).expect("Error generating dummy circuit"), pp, vk, b"dusk" ,p_inp, proof),
         "transfer-send-to-contract-obfuscated" => verify_proof(SendToContractObfuscatedCircuit::default(), pp, vk, b"dusk" ,p_inp, proof),
         "transfer-send-to-contract-transparent" => verify_proof(SendToContractTransparentCircuit::default(), pp, vk, b"dusk" ,p_inp, proof),
         "transfer-withdraw-from-obfuscated" => verify_proof(WithdrawFromObfuscatedCircuit::default(), pp, vk, b"dusk" ,p_inp, proof),
+        "bid-correctness" => verify_proof(CorrectnessCircuit::default(), pp, vk, b"dusk", p_inp, proof),
         _ => false,
     }
 }

--- a/tests/contracts/verify_proof/src/lib.rs
+++ b/tests/contracts/verify_proof/src/lib.rs
@@ -28,7 +28,6 @@ mod hosted {
 
     use super::*;
     use alloc::vec::Vec;
-    use dusk_bls12_381::BlsScalar;
 
     use canonical::{BridgeStore, ByteSink, ByteSource, Canon, Id32, Store};
     use dusk_abi::ReturnValue;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -303,7 +303,6 @@ fn proof_verifier() {
 
     // We store the current reference string here, so we can temporarily change
     // it for the test, and then change it back once finished.
-    let old_crs_file_name = "temp_crs.bin";
     let old_crs = rusk_profile::get_common_reference_string();
 
     let pp = unsafe {
@@ -384,8 +383,6 @@ fn proof_verifier() {
     if old_crs.is_ok() {
         rusk_profile::set_common_reference_string(old_crs.unwrap())
             .expect("Error restoring CRS in rusk_profile");
-        std::fs::remove_file(old_crs_file_name)
-            .expect("Could not remove temporary CRS holder file");
     } else {
         rusk_profile::delete_common_reference_string().unwrap();
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -312,18 +312,19 @@ fn proof_verifier() {
     }
 
     let pp = unsafe {
-        let buff = std::fs::read("tests/pub_params_dev.bin")
+        let buff = std::fs::read("temp_crs.bin")
             .expect("Error reading from PubParams file");
         PublicParameters::from_slice_unchecked(buff.as_slice())
             .expect("PubParams deser error")
     };
 
-    rusk_profile::set_common_reference_string("tests/pub_params_dev.bin")
+    rusk_profile::set_common_reference_string(pp.to_raw_bytes())
         .expect("Error setting CRS in rusk_profile");
     let mut circuit = ExecuteCircuit::<17, 15>::create_dummy_circuit::<_, MS>(
         &mut rand::thread_rng(),
         1,
         1,
+        true,
     )
     .expect("Error creating a dummy setup");
 
@@ -355,6 +356,7 @@ fn proof_verifier() {
                 &mut rand::thread_rng(),
                 1,
                 1,
+                true,
             )
             .expect("Error creating a dummy setup");
         circuit.verify_proof(&pp, &vk, b"dusk", &proof, &pi).is_ok()
@@ -379,7 +381,7 @@ fn proof_verifier() {
 
     // If we stored the old CRS, let's restore it at the end of the test, too.
     if std::fs::metadata(old_crs_file_name).is_ok() {
-        rusk_profile::set_common_reference_string(old_crs_file_name)
+        rusk_profile::set_common_reference_string(pp.to_raw_bytes())
             .expect("Error restoring CRS in rusk_profile");
         std::fs::remove_file(old_crs_file_name)
             .expect("Could not remove temporary CRS holder file");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -309,6 +309,8 @@ fn proof_verifier() {
     if let Ok(_) = old_crs {
         std::fs::File::create(old_crs_file_name).unwrap();
         std::fs::write(old_crs_file_name, old_crs.unwrap().as_slice()).unwrap();
+    } else {
+        std::fs::write(old_crs_file_name, PublicParameters::setup(1<<15, &mut rand::thread_rng()).unwrap().to_raw_bytes()).unwrap();
     }
 
     let pp = unsafe {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -315,11 +315,6 @@ fn proof_verifier() {
     rusk_profile::set_common_reference_string(pp.to_raw_bytes())
         .expect("Error setting CRS in rusk_profile");
 
-    // This is the same code that runs inside the ABICall and fails too.
-    unsafe{PublicParameters::from_slice_unchecked(&rusk_profile::get_common_reference_string().unwrap())
-        .expect("PubParams deser error");}
-
-
     let mut circuit = ExecuteCircuit::<17, 15>::create_dummy_circuit::<_, MS>(
         &mut rand::thread_rng(),
         1,


### PR DESCRIPTION
- Adds `CorrectnessCircuit` as a new entry in the `verify_proof` ABICall map. Closes #149 
- Updates the deps to the latest versions pulling from crates.io when possible. Closes #152