### PR TITLE
Bump to `0.4.0` (again)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,11 @@ canonical = { version = "0.5" , features = ["host"] }
 canonical_host = "0.5"
 canonical_derive = "0.5"
 dusk-kelvin-map = "0.3"
-dusk-plonk = "0.5"
-rusk-profile = {git = "https://github.com/dusk-network/rusk/", tag = "rusk-profile-0.1.0"}
-transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-circuits-0.1.0"}
-anyhow = {version = "1.0", optional = true}
-rand = "0.7"
-dusk-bls12_381 = "0.6"
-dusk-bytes = "0.1"
-bincode = "1.0"
 
 [dev-dependencies]
-rand = "0.7"
-transfer-circuits = {git = "https://github.com/dusk-network/rusk/", tag = "transfer-circuits-0.1.0", features = ["builder", "builder-no-rusk-profile-keys"]}
+dusk-bls12_381 = "0.6"
+dusk-bytes = "0.1"
+
 # test contracts
 counter = { path = "tests/contracts/counter", features = ["host"] }
 fibonacci = { path = "tests/contracts/fibonacci", features = ["host"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-vm"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>"


### PR DESCRIPTION
For some weird behavior the bump to `0.4.0` wasn't applied.
Looks like it was considered somehow as no part of this repo.

See also: <https://github.com/dusk-network/rusk-vm/commit/d20219b07568758c8e3cda76f384cfdd9f7548e8>

- Remove unused deps from Cargo.toml