### PR TITLE
Implement bytecode instrumentation at deploy time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ dusk-bytes = "0.1"
 
 # test contracts
 counter = { path = "tests/contracts/counter", features = ["host"] }
+counter_float = { path = "tests/contracts/counter_float", features = ["host"] }
 fibonacci = { path = "tests/contracts/fibonacci", features = ["host"] }
 delegator = { path = "tests/contracts/delegator", features = ["host"] }
 stack = { path = "tests/contracts/stack", features = ["host"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ authors = [
 edition = "2018"
 
 [dependencies]
-wasmi = "0.6.0"
+wasmi = "0.7"
 wasmi-validation = "0.3"
 parity-wasm = "0.41"
-pwasm-utils = "0.12.0"
+pwasm-utils = "0.16"
 failure = "0.1"
 
 dusk-abi = "0.7"

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -14,14 +14,16 @@ use wasmi_validation::{validate_module, PlainValidator};
 
 /// A representation of a contract with a state and bytecode
 #[derive(Clone, Canon)]
-pub struct Contract {
+pub struct Contract<S: Store> {
     state: ContractState,
     pub(crate) code: Vec<u8>,
+    #[doc(hidden)]
+    _marker: PhantomData<S>,
 }
 
-impl Contract {
+impl<S: Store> Contract<S> {
     /// Create a new Contract with initial state and code
-    pub fn new<State, Code, S>(
+    pub fn new<State, Code>(
         state: State,
         code: Code,
         store: &S,
@@ -29,22 +31,17 @@ impl Contract {
     where
         State: Canon<S>,
         Code: Into<Vec<u8>>,
-        S: Store,
     {
         Ok(Contract {
             state: ContractState::from_canon(&state, &store)?,
             code: code.into(),
+            _marker: PhantomData::<S>,
         })
     }
 
     /// Returns a reference to the contract bytecode
     pub fn bytecode(&self) -> &[u8] {
         &self.code
-    }
-
-    /// Replaces the bytecode of a contract instance by another one.
-    fn update_bytecode(&mut self, bytecode: Vec<u8>) {
-        self.code = bytecode;
     }
 
     /// Returns a reference to the contract state
@@ -56,126 +53,108 @@ impl Contract {
     pub fn state_mut(&mut self) -> &mut ContractState {
         &mut self.state
     }
-}
 
-pub struct ContractInstrumenter<'a, S: Store> {
-    module: Module,
-    schedule: &'a crate::Schedule,
-    #[doc(hidden)]
-    _marker: PhantomData<S>,
-}
-
-impl<'a, S: Store> ContractInstrumenter<'a, S> {
     /// Creates a new [`ContractInstrumenter`] instance from a mutable reference
     /// to a [`Contract`] and a [`Schedule`] config.
-    pub(crate) fn instrument(
-        contract: &'a mut Contract,
-        schedule: &'a Schedule,
-    ) -> Result<(), VMError<S>> {
-        // Instanciate the instrumenter
-        let code = contract.clone().code;
-        let instrumenter = Self {
-            module: elements::deserialize_buffer(code.as_slice())
-                .map_err(|_| VMError::InvalidWASMModule)?,
-            schedule,
-            _marker: PhantomData::<S>,
-        };
-
-        // Apply instrumentation.
-        let new_bytecode = instrumenter.apply_module_config()?;
-
-        // Update the Contract instance bytecode.
-        contract.update_bytecode(new_bytecode);
-
-        Ok(())
-    }
-
-    /// Given a ContractInstrumenter instance, it applies the
-    /// instrumentalization to the bytecode and returning the newly
-    /// generated one after checking that it is a valid WASM module.
-    fn apply_module_config(self) -> Result<Vec<u8>, VMError<S>> {
-        let ruleset = pwasm_utils::rules::Set::new(
-            self.schedule.regular_op_cost as u32,
-            Default::default(),
-        )
-        .with_grow_cost(self.schedule.grow_mem_cost as u32)
-        .with_forbidden_floats();
-
-        self.inject_gas_metering(ruleset)?
-            .inject_stack_height_metering()?
-            .ensure_table_size_limit(&crate::Schedule::default())?
-            .validate_module()
-    }
-
-    /// Check the validity of a [`Module`] pertaining to a
-    /// [`ContractInstrumenter`] and in case it is, return it serialized as
-    /// bytecode.
-    fn validate_module(self) -> Result<Vec<u8>, VMError<S>> {
-        let _ = validate_module::<PlainValidator>(&self.module)
+    pub(crate) fn instrument(mut self) -> Result<Self, VMError<S>> {
+        let module = elements::deserialize_buffer(self.code.as_slice())
             .map_err(|_| VMError::InvalidWASMModule)?;
 
-        self.module.to_bytes().map_err(|_| {
-            VMError::InstrumentalizationError(
-                "Failed to serialize the WASM Module back to plain bytecode"
-                    .to_string(),
-            )
-        })
-    }
+        // Apply instrumentalization & Update the Contract instance bytecode.
+        self.code = apply_module_config(module)?;
 
-    /// Ensures that tables declared in the module are not too big.
-    fn ensure_table_size_limit(
-        self,
-        schedule: &Schedule,
-    ) -> Result<Self, VMError<S>> {
-        if let Some(table_section) = self.module.table_section() {
-            // In Wasm MVP spec, there may be at most one table declared. Double
-            // check this explicitly just in case the Wasm version
-            // changes.
-            if table_section.entries().len() > 1 {
+        Ok(self)
+    }
+}
+
+/// Given a [`Contract`] instance, it applies the
+/// instrumentalization to the bytecode and returning the newly
+/// generated one after checking that it is a valid WASM module.
+fn apply_module_config<S: Store>(
+    mut module: Module,
+) -> Result<Vec<u8>, VMError<S>> {
+    let schedule = crate::Schedule::default();
+
+    let ruleset = pwasm_utils::rules::Set::new(
+        schedule.regular_op_cost as u32,
+        Default::default(),
+    )
+    .with_grow_cost(schedule.grow_mem_cost as u32)
+    .with_forbidden_floats();
+
+    module = inject_gas_metering(module, ruleset)?;
+    module = inject_stack_height_metering(module, &schedule)?;
+    ensure_table_size_limit(&module, &schedule)?;
+    validate_mod(module)
+}
+
+/// Check the validity of a [`Module`] pertaining to a
+/// [`Contract`] and in case it is, return it serialized as
+/// bytecode.
+fn validate_mod<S: Store>(module: Module) -> Result<Vec<u8>, VMError<S>> {
+    let _ = validate_module::<PlainValidator>(&module)
+        .map_err(|_| VMError::InvalidWASMModule)?;
+
+    module.to_bytes().map_err(|_| {
+        VMError::InstrumentalizationError(
+            "Failed to serialize the WASM Module back to plain bytecode"
+                .to_string(),
+        )
+    })
+}
+
+/// Ensures that tables declared in the module are not too big.
+fn ensure_table_size_limit<S: Store>(
+    module: &Module,
+    schedule: &Schedule,
+) -> Result<(), VMError<S>> {
+    if let Some(table_section) = module.table_section() {
+        // In Wasm MVP spec, there may be at most one table declared. Double
+        // check this explicitly just in case the Wasm version
+        // changes.
+        if table_section.entries().len() > 1 {
+            return Err(VMError::InstrumentalizationError(
+                "multiple tables declared".to_string(),
+            ));
+        }
+        if let Some(table_type) = table_section.entries().first() {
+            // Check the table's initial size as there is no instruction or
+            // environment function capable of growing the
+            // table.
+            if table_type.limits().initial() > schedule.max_table_size {
                 return Err(VMError::InstrumentalizationError(
-                    "multiple tables declared".to_string(),
+                    "table exceeds maximum size allowed".to_string(),
                 ));
             }
-            if let Some(table_type) = table_section.entries().first() {
-                // Check the table's initial size as there is no instruction or
-                // environment function capable of growing the
-                // table.
-                if table_type.limits().initial() > schedule.max_table_size {
-                    return Err(VMError::InstrumentalizationError(
-                        "table exceeds maximum size allowed".to_string(),
-                    ));
-                }
-            }
         }
-        Ok(self)
     }
+    Ok(())
+}
 
-    /// Injects gas metering instrumentation into the Module.
-    fn inject_gas_metering<T>(mut self, ruleset: T) -> Result<Self, VMError<S>>
-    where
-        T: pwasm_utils::rules::Rules,
-    {
-        self.module =
-            pwasm_utils::inject_gas_counter(self.module, &ruleset, "env")
-                .map_err(|_| {
-                    VMError::InstrumentalizationError(
-                        "gas instrumentation injection failed".to_string(),
-                    )
-                })?;
-        Ok(self)
-    }
-
-    /// Injects stack height metering instrumentation into the Module.
-    fn inject_stack_height_metering(mut self) -> Result<Self, VMError<S>> {
-        self.module = pwasm_utils::stack_height::inject_limiter(
-            self.module.clone(),
-            self.schedule.max_stack_height,
+/// Injects gas metering instrumentation into the Module.
+fn inject_gas_metering<T, S: Store>(
+    module: Module,
+    ruleset: T,
+) -> Result<Module, VMError<S>>
+where
+    T: pwasm_utils::rules::Rules,
+{
+    pwasm_utils::inject_gas_counter(module, &ruleset, "env").map_err(|_| {
+        VMError::InstrumentalizationError(
+            "gas instrumentation injection failed".to_string(),
         )
+    })
+}
+
+/// Injects stack height metering instrumentation into the Module.
+fn inject_stack_height_metering<S: Store>(
+    module: Module,
+    schedule: &Schedule,
+) -> Result<Module, VMError<S>> {
+    pwasm_utils::stack_height::inject_limiter(module, schedule.max_stack_height)
         .map_err(|_| {
             VMError::InstrumentalizationError(
                 "stack height instrumentation injection failed".to_string(),
             )
-        })?;
-        Ok(self)
-    }
+        })
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -9,7 +9,7 @@ use canonical::{Canon, Store};
 use canonical_derive::Canon;
 use core::marker::PhantomData;
 pub use dusk_abi::{ContractId, ContractState};
-use parity_wasm::elements::{self, Module, Type, ValueType};
+use parity_wasm::elements::{self, Module};
 use wasmi_validation::{validate_module, PlainValidator};
 
 /// A representation of a contract with a state and bytecode

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -4,15 +4,19 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use crate::{Schedule, VMError};
 use canonical::{Canon, Store};
 use canonical_derive::Canon;
+use core::marker::PhantomData;
 pub use dusk_abi::{ContractId, ContractState};
+use parity_wasm::elements::{self, Module, Type, ValueType};
+use wasmi_validation::{validate_module, PlainValidator};
 
 /// A representation of a contract with a state and bytecode
 #[derive(Clone, Canon)]
 pub struct Contract {
     state: ContractState,
-    code: Vec<u8>,
+    pub(crate) code: Vec<u8>,
 }
 
 impl Contract {
@@ -46,5 +50,173 @@ impl Contract {
     /// Returns a mutable reference to the contract state
     pub fn state_mut(&mut self) -> &mut ContractState {
         &mut self.state
+    }
+}
+
+pub struct ContractInstrumenter<'a, S: Store> {
+    module: Module,
+    schedule: &'a crate::Schedule,
+    #[doc(hidden)]
+    _marker: PhantomData<S>,
+}
+
+impl<'a, S: Store> ContractInstrumenter<'a, S> {
+    /// Creates a new [`ContractInstrumenter`] instance from a bytecode source
+    /// and a Schedule config.
+    pub fn new(
+        bytecode: &[u8],
+        schedule: &'a Schedule,
+    ) -> Result<ContractInstrumenter<'a, S>, VMError<S>> {
+        Ok(Self {
+            module: elements::deserialize_buffer(bytecode)
+                .map_err(|_| VMError::InvalidWASMModule)?,
+            schedule,
+            _marker: PhantomData::<S>,
+        })
+    }
+
+    /// Serializes the [`ContractInstrumenter`] bytecode returning an
+    /// error if anything in the Module is wrongly configured.
+    pub fn bytecode(&self) -> Result<Vec<u8>, VMError<S>> {
+        self.module
+            .clone()
+            .to_bytes()
+            .map_err(|_| VMError::InvalidWASMModule)
+    }
+
+    /// Applies all of the checks and instrumentation injections to a contract
+    /// bytecode.
+    /// It also validates the module after the instrumentation has been applied.
+    pub fn apply_module_config(&mut self) -> Result<(), VMError<S>> {
+        self.ensure_no_floating_types()?;
+        self.ensure_table_size_limit(&crate::Schedule::default())?;
+        self.inject_gas_metering()?;
+        self.inject_stack_height_metering()?;
+        self.validate_module()
+    }
+
+    pub fn validate_module(&self) -> Result<(), VMError<S>> {
+        validate_module::<PlainValidator>(&self.module)
+            .map_err(|_| VMError::InvalidWASMModule)
+    }
+
+    /// Filter that ensures that there's no floating point usage inside of the
+    /// bytecode of the ContractInstrumenter module.
+    fn ensure_no_floating_types(&self) -> Result<(), VMError<S>> {
+        // TODO: Check wether the type section contains the `ValueType`s used
+        // across the other sections too. Don't think so. But we should
+        // check.
+        if let Some(global_section) = self.module.global_section() {
+            for global in global_section.entries() {
+                match global.global_type().content_type() {
+                    ValueType::F32 | ValueType::F64 => return Err(VMError::InstrumentationError(
+                        "use of floating point type in globals is forbidden".to_string(),
+                    )),
+                    _ => {}
+                }
+            }
+        }
+
+        if let Some(code_section) = self.module.code_section() {
+            for func_body in code_section.bodies() {
+                for local in func_body.locals() {
+                    match local.value_type() {
+                        ValueType::F32 | ValueType::F64 => return Err(
+                            VMError::InstrumentationError("use of floating point type in locals is forbidden".to_string()),
+                        ),
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        if let Some(type_section) = self.module.type_section() {
+            for wasm_type in type_section.types() {
+                match wasm_type {
+                    Type::Function(func_type) => {
+                        let return_type = func_type.return_type();
+                        for value_type in
+                            func_type.params().iter().chain(return_type.iter())
+                        {
+                            match value_type {
+								ValueType::F32 | ValueType::F64 => {
+									return Err(
+										VMError::InstrumentationError("use of floating point type in function types is forbidden".to_string()),
+									)
+								}
+								_ => {}
+							}
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Ensures that tables declared in the module are not too big.
+    fn ensure_table_size_limit(
+        &self,
+        schedule: &Schedule,
+    ) -> Result<(), VMError<S>> {
+        if let Some(table_section) = self.module.table_section() {
+            // In Wasm MVP spec, there may be at most one table declared. Double
+            // check this explicitly just in case the Wasm version
+            // changes.
+            if table_section.entries().len() > 1 {
+                return Err(VMError::InstrumentationError(
+                    "multiple tables declared".to_string(),
+                ));
+            }
+            if let Some(table_type) = table_section.entries().first() {
+                // Check the table's initial size as there is no instruction or
+                // environment function capable of growing the
+                // table.
+                if table_type.limits().initial() > schedule.max_table_size {
+                    return Err(VMError::InstrumentationError(
+                        "table exceeds maximum size allowed".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Injects gas metering instrumentation into the Module.
+    fn inject_gas_metering(&mut self) -> Result<(), VMError<S>> {
+        let gas_rules = pwasm_utils::rules::Set::new(
+            self.schedule.regular_op_cost as u32,
+            Default::default(),
+        )
+        .with_grow_cost(self.schedule.grow_mem_cost as u32)
+        .with_forbidden_floats();
+
+        self.module = pwasm_utils::inject_gas_counter(
+            self.module.clone(),
+            &gas_rules,
+            "env",
+        )
+        .map_err(|_| {
+            VMError::InstrumentationError(
+                "gas instrumentation injection failed".to_string(),
+            )
+        })?;
+
+        Ok(())
+    }
+
+    /// Injects stack height metering instrumentation into the Module.
+    fn inject_stack_height_metering(&mut self) -> Result<(), VMError<S>> {
+        self.module = pwasm_utils::stack_height::inject_limiter(
+            self.module.clone(),
+            self.schedule.max_stack_height,
+        )
+        .map_err(|_| {
+            VMError::InstrumentationError(
+                "stack height instrumentation injection failed".to_string(),
+            )
+        })?;
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ where
     /// Contract could not be found in the state
     UnknownContract,
     /// WASM code instrumentation error.
-    InstrumentationError(String),
+    InstrumentalizationError(String),
     /// WASM threw an error
     WASMError(failure::Error),
     /// wasmi trap triggered
@@ -124,7 +124,7 @@ impl<S: Store> fmt::Display for VMError<S> {
             VMError::InvalidABICall => write!(f, "Invalid ABI Call")?,
             VMError::IOError(e) => write!(f, "Input/Output Error ({:?})", e)?,
             VMError::Trap(e) => write!(f, "Trap ({:?})", e)?,
-            VMError::InstrumentationError(instr_phase) => {
+            VMError::InstrumentalizationError(instr_phase) => {
                 write!(f, "Instrumentation Error \"{}\"", instr_phase)?
             }
             VMError::WasmiError(e) => write!(f, "WASMI Error ({:?})", e)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ where
     NotEnoughFunds,
     /// Contract could not be found in the state
     UnknownContract,
+    /// WASM code instrumentation error.
+    InstrumentationError(String),
     /// WASM threw an error
     WASMError(failure::Error),
     /// wasmi trap triggered
@@ -122,6 +124,9 @@ impl<S: Store> fmt::Display for VMError<S> {
             VMError::InvalidABICall => write!(f, "Invalid ABI Call")?,
             VMError::IOError(e) => write!(f, "Input/Output Error ({:?})", e)?,
             VMError::Trap(e) => write!(f, "Trap ({:?})", e)?,
+            VMError::InstrumentationError(instr_phase) => {
+                write!(f, "Instrumentation Error \"{}\"", instr_phase)?
+            }
             VMError::WasmiError(e) => write!(f, "WASMI Error ({:?})", e)?,
             VMError::UnknownContract => write!(f, "Unknown Contract")?,
             VMError::InvalidWASMModule => write!(f, "Invalid WASM module")?,

--- a/src/state.rs
+++ b/src/state.rs
@@ -82,19 +82,15 @@ where
         &mut self,
         mut contract: Contract,
     ) -> Result<ContractId, VMError<S>> {
-        let schedule = crate::Schedule::default();
-        let mut instrumenter =
-            ContractInstrumenter::new(contract.bytecode(), &schedule)?;
-
-        // Apply instrumentation & validate the module.
-        instrumenter.apply_module_config()?;
-
+        // Before any instrumentation is applied, generate the contract id.
         let id: ContractId =
-            S::Ident::from_bytes(instrumenter.bytecode()?.as_ref()).into();
+            S::Ident::from_bytes(contract.code.as_ref()).into();
 
-        // Assign to the Contract that we're going to store the instrumented
-        // bytecode.
-        contract.code = instrumenter.bytecode()?.clone();
+        // Instrumentalize the contract.
+        ContractInstrumenter::instrument(
+            &mut contract,
+            &crate::Schedule::default(),
+        )?;
 
         // FIXME: This shoul check wether the contract is already deployed.
         let _ = self

--- a/tests/contracts/counter_float/Cargo.toml
+++ b/tests/contracts/counter_float/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "counter_float"
+version = "0.1.0"
+authors = ["Carlos Pérez <carlos@dusk.network>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+canonical = { version = "0.5", default-features = false }
+canonical_derive = "0.5"
+canonical_host = { version = "0.5", optional = true }
+
+dusk-abi = "0.7"
+
+[features]
+host = ["canonical_host"]

--- a/tests/contracts/counter_float/Makefile
+++ b/tests/contracts/counter_float/Makefile
@@ -1,0 +1,6 @@
+all: ## Generate the optimized WASM for the contract given
+	@cargo rustc \
+		--manifest-path=./Cargo.toml \
+		--release \
+		--target wasm32-unknown-unknown \
+		-- -C link-args=-s

--- a/tests/contracts/counter_float/rustfmt.toml
+++ b/tests/contracts/counter_float/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 80
+wrap_comments = true

--- a/tests/contracts/counter_float/src/lib.rs
+++ b/tests/contracts/counter_float/src/lib.rs
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! This contract is meant to be used to test whether the `deploy`
+//! instrumentization rules are applied correctly denying the deployment of any
+//! contract that uses floating point operations.
+
+#![cfg_attr(not(feature = "host"), no_std)]
+#![feature(core_intrinsics, lang_items, alloc_error_handler)]
+
+use canonical::{Canon, Sink, Source, Store};
+use core::mem;
+
+// transaction ids
+pub const INCREMENT: u8 = 0;
+
+#[derive(Clone, Debug)]
+pub struct CounterFloat {
+    junk: f32,
+    value: f32,
+}
+
+impl<S> Canon<S> for CounterFloat
+where
+    S: Store,
+{
+    fn write(&self, sink: &mut impl Sink<S>) -> Result<(), S::Error> {
+        sink.copy_bytes(&self.junk.to_le_bytes());
+        sink.copy_bytes(&self.value.to_le_bytes());
+        Ok(())
+    }
+
+    fn read(source: &mut impl Source<S>) -> Result<Self, S::Error> {
+        let bytes = source.read_bytes(mem::size_of::<f32>());
+        let mut float = [0u8; 4];
+        float.copy_from_slice(&bytes[0..4]);
+        let junk = f32::from_le_bytes(float);
+        float.copy_from_slice(&bytes[4..]);
+        let value = f32::from_le_bytes(float);
+        Ok(Self { junk, value })
+    }
+
+    fn encoded_len(&self) -> usize {
+        mem::size_of::<f32>() * 2
+    }
+}
+
+impl CounterFloat {
+    pub fn new(value: f32) -> Self {
+        CounterFloat {
+            junk: 0.55f32,
+            value,
+        }
+    }
+}
+
+#[cfg(not(feature = "host"))]
+mod hosted {
+    use super::*;
+
+    use canonical::{BridgeStore, ByteSink, ByteSource, Id32, Store};
+    use dusk_abi::{ContractState, ReturnValue};
+
+    const PAGE_SIZE: usize = 1024 * 4;
+
+    type BS = BridgeStore<Id32>;
+
+    impl CounterFloat {
+        // We add `no_mangle` to prevent any compiler optimizations to remove
+        // the floating point usage from the code.
+        #[no_mangle]
+        pub fn increment(&mut self) {
+            self.value += 1.88f32;
+        }
+    }
+
+    fn transaction(
+        bytes: &mut [u8; PAGE_SIZE],
+    ) -> Result<(), <BS as Store>::Error> {
+        let bs = BS::default();
+        let mut source = ByteSource::new(bytes, &bs);
+
+        // read self.
+        let mut slf: CounterFloat = Canon::<BS>::read(&mut source)?;
+        // read transaction id
+        let tid: u8 = Canon::<BS>::read(&mut source)?;
+        match tid {
+            // increment (&Self)
+            INCREMENT => {
+                slf.increment();
+                let mut sink = ByteSink::new(&mut bytes[..], &bs);
+                // return new state
+                Canon::<BS>::write(
+                    &ContractState::from_canon(&slf, &bs)?,
+                    &mut sink,
+                )?;
+
+                // return value
+                Canon::<BS>::write(
+                    &ReturnValue::from_canon(&(), &bs)?,
+                    &mut sink,
+                )
+            }
+            _ => panic!(""),
+        }
+    }
+
+    #[no_mangle]
+    fn t(bytes: &mut [u8; PAGE_SIZE]) {
+        // todo, handle errors here
+        transaction(bytes).unwrap()
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,6 +17,7 @@ use dusk_abi::{HostModule, Module, Query, ReturnValue, Transaction};
 
 use block_height::BlockHeight;
 use counter::Counter;
+use counter_float::CounterFloat;
 use delegator::Delegator;
 use fibonacci::Fibonacci;
 use host_fn::HostFnTest;
@@ -150,6 +151,23 @@ fn out_of_gas_aborts_execution() {
 
     // Ensure all gas is consumed even the tx did not succeed.
     assert_eq!(gas.gas_left(), 0);
+}
+
+#[test]
+fn deploy_fails_with_floats() {
+    let counter = CounterFloat::new(9.99f32);
+
+    let store = MS::new();
+
+    let code = include_bytes!(
+        "../target/wasm32-unknown-unknown/release/counter_float.wasm"
+    );
+
+    let contract = Contract::new(counter, code.to_vec(), &store).unwrap();
+
+    let mut network = NetworkState::<MS>::default();
+
+    assert!(network.deploy(contract).is_err());
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -149,15 +149,7 @@ fn out_of_gas_aborts_execution() {
         .is_err());
 
     // Ensure all gas is consumed even the tx did not succeed.
-    assert_eq!(gas.gas_left() == 0);
-
-    // FIXME: Query actually consumes gas. Should this be the expected?
-    assert_eq!(
-        network
-            .query::<_, i32>(contract_id, counter::READ_VALUE, &mut gas)
-            .expect("Query error"),
-        99
-    );
+    assert_eq!(gas.gas_left(), 0);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -145,9 +145,9 @@ fn out_of_gas_aborts_execution() {
 
     let mut gas = GasMeter::with_limit(1);
 
-    assert!(network
-        .transact::<_, ()>(contract_id, counter::INCREMENT, &mut gas)
-        .is_err());
+    let should_be_err =
+        network.transact::<_, ()>(contract_id, counter::INCREMENT, &mut gas);
+    assert!(format!("{:?}", should_be_err).contains("Out of Gas error"));
 
     // Ensure all gas is consumed even the tx did not succeed.
     assert_eq!(gas.gas_left(), 0);
@@ -167,7 +167,10 @@ fn deploy_fails_with_floats() {
 
     let mut network = NetworkState::<MS>::default();
 
-    assert!(network.deploy(contract).is_err());
+    assert!(matches!(
+        network.deploy(contract),
+        Err(rusk_vm::VMError::InstrumentalizationError(_))
+    ));
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -94,6 +94,73 @@ fn counter_trivial() {
 }
 
 #[test]
+fn gas_consumtion_works() {
+    let counter = Counter::new(99);
+
+    let store = MS::new();
+
+    let code =
+        include_bytes!("../target/wasm32-unknown-unknown/release/counter.wasm");
+
+    let contract = Contract::new(counter, code.to_vec(), &store).unwrap();
+
+    let mut network = NetworkState::<MS>::default();
+
+    let contract_id = network.deploy(contract).expect("Deploy error");
+
+    let mut gas = GasMeter::with_limit(1_000_000_000);
+
+    assert_eq!(
+        network
+            .transact::<_, ()>(contract_id, counter::INCREMENT, &mut gas)
+            .expect("Transaction error"),
+        ()
+    );
+
+    assert_eq!(
+        network
+            .query::<_, i32>(contract_id, counter::READ_VALUE, &mut gas)
+            .expect("Query error"),
+        100
+    );
+    assert_ne!(gas.spent(), 0);
+    assert!(gas.gas_left() < 1_000_000_000);
+}
+
+#[test]
+fn out_of_gas_aborts_execution() {
+    let counter = Counter::new(99);
+
+    let store = MS::new();
+
+    let code =
+        include_bytes!("../target/wasm32-unknown-unknown/release/counter.wasm");
+
+    let contract = Contract::new(counter, code.to_vec(), &store).unwrap();
+
+    let mut network = NetworkState::<MS>::default();
+
+    let contract_id = network.deploy(contract).expect("Deploy error");
+
+    let mut gas = GasMeter::with_limit(1);
+
+    assert!(network
+        .transact::<_, ()>(contract_id, counter::INCREMENT, &mut gas)
+        .is_err());
+
+    // Ensure all gas is consumed even the tx did not succeed.
+    assert_eq!(gas.gas_left() == 0);
+
+    // FIXME: Query actually consumes gas. Should this be the expected?
+    assert_eq!(
+        network
+            .query::<_, i32>(contract_id, counter::READ_VALUE, &mut gas)
+            .expect("Query error"),
+        99
+    );
+}
+
+#[test]
 fn delegated_call() {
     let counter = Counter::new(99);
     let delegator = Delegator;


### PR DESCRIPTION
As stated in #115 and #116 we need a way to instrumentate the WASM
bytecode of the contracts deployed to be able to inject gas_metering
tools as well as removal of floating point operations among other
checks.

This PR adds the tooling and instrumentation linked to the
`NetworksState::deploy()` fn adding the following checks and
instrumentation for the bytecode:
- No floating point ops are used in the contract.
- Gas metering tools are injected correctly and work.
- Stack height metering tools so that we never pass the maximum allowed.
- Table size limits used in the wasm Modules are not bigger than what is
allowed.
- Validity check of all of the previous instrumentation.

Resolves: #115, #116.

This leaves as a new issue to address: #174 