### PR TITLE
Add `gas_consumed` host function logic 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ counter = { path = "tests/contracts/counter", features = ["host"] }
 counter_float = { path = "tests/contracts/counter_float", features = ["host"] }
 fibonacci = { path = "tests/contracts/fibonacci", features = ["host"] }
 delegator = { path = "tests/contracts/delegator", features = ["host"] }
+gas_consumed = { path = "tests/contracts/gas_consumed", features = ["host"] }
 stack = { path = "tests/contracts/stack", features = ["host"] }
 block_height = { path = "tests/contracts/block_height", features = ["host"] }
 self_snapshot = { path = "tests/contracts/self_snapshot", features = ["host"] }
@@ -45,3 +46,6 @@ harness = false
 members = [
     "tests/contracts/*",
 ]
+
+[patch.crates-io]
+dusk-abi = {git = "https://github.com/dusk-network/dusk-abi", branch = "gas_metering"}

--- a/src/call_context.rs
+++ b/src/call_context.rs
@@ -257,6 +257,10 @@ where
         self.gas_meter
     }
 
+    pub fn gas_consumed(&self) -> u64 {
+        self.gas_meter.spent()
+    }
+
     pub fn top(&self) -> &StackFrame {
         self.stack.last().expect("Invalid stack")
     }

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -37,6 +37,8 @@ pub struct GasMeter {
 impl GasMeter {
     /// Minimum amount of gas that has to be used in order to call a contract
     /// execution.
+    // TODO: Add the correct value here that changes in respect to the transfer
+    // contract.
     pub const MIN_TERMINATION_GAS_REQUIRED: Gas = 70440;
 
     /// Creates a new `GasMeter` with given initial gas.

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -17,7 +17,7 @@ pub enum GasMeterResult {
 }
 
 impl GasMeterResult {
-    pub fn is_out_of_gas(&self) -> bool {
+    pub const fn is_out_of_gas(&self) -> bool {
         match *self {
             GasMeterResult::OutOfGas => true,
             GasMeterResult::Proceed => false,

--- a/src/ops/gas.rs
+++ b/src/ops/gas.rs
@@ -29,3 +29,30 @@ impl<S: Store> AbiCall<S> for Gas {
         Ok(None)
     }
 }
+
+pub struct GasConsumed;
+
+impl GasConsumed {
+    pub const GAS_CONSUMED_CALL_COST: u64 = 9165;
+}
+
+impl<S: Store> AbiCall<S> for GasConsumed {
+    const ARGUMENTS: &'static [ValueType] = &[];
+    const RETURN: Option<ValueType> = Some(ValueType::I64);
+
+    fn call(
+        context: &mut CallContext<S>,
+        _args: RuntimeArgs,
+    ) -> Result<Option<RuntimeValue>, VMError<S>> {
+        // Note that when this function returns, the costs that invoking this
+        // host function has are not taken into account here, they are
+        // once the host call execution finnishes. Therefore, we need to
+        // add to the result the gas_consumed fn cost.
+        // FIXME: This will not always be correct since if the `gas_consumed =
+        // ALL` the gas, this will add the extra cost of the call
+        // which can't be consumed since it's not even there.
+        Ok(Some(RuntimeValue::from(
+            context.gas_consumed() + GasConsumed::GAS_CONSUMED_CALL_COST,
+        )))
+    }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -80,6 +80,7 @@ abi_resolver! {
         7, "transact" => transact::ApplyTransaction,
         9, "callee" => callee::Callee,
         10, "gas" => gas::Gas,
-        11, "block_height" => block_height::BlockHeight
+        11, "block_height" => block_height::BlockHeight,
+        12, "gas_consumed" => gas::GasConsumed
     }
 }

--- a/tests/contracts/gas_consumed/Cargo.toml
+++ b/tests/contracts/gas_consumed/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "gas_consumed"
+version = "0.1.0"
+authors = ["CPerezz <carlos@dusk.network>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+canonical = { version = "0.5", default-features = false }
+canonical_derive = "0.5"
+canonical_host = { version = "0.5", optional = true }
+
+dusk-abi = "0.7"
+
+[features]
+host = ["canonical_host"]
+
+[patch.crates-io]
+dusk-abi = {git = "https://github.com/dusk-network/dusk-abi", branch = "gas_metering"}

--- a/tests/contracts/gas_consumed/Makefile
+++ b/tests/contracts/gas_consumed/Makefile
@@ -1,0 +1,6 @@
+all: ## Generate the optimized WASM for the contract given
+	@cargo rustc \
+		--manifest-path=./Cargo.toml \
+		--release \
+		--target wasm32-unknown-unknown \
+		-- -C link-args=-s

--- a/tests/contracts/gas_consumed/rustfmt.toml
+++ b/tests/contracts/gas_consumed/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 80
+wrap_comments = true

--- a/tests/contracts/gas_consumed/src/lib.rs
+++ b/tests/contracts/gas_consumed/src/lib.rs
@@ -1,0 +1,170 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+#![cfg_attr(not(feature = "host"), no_std)]
+#![feature(core_intrinsics, lang_items, alloc_error_handler)]
+
+use canonical::Canon;
+use canonical_derive::Canon;
+
+// query ids
+pub const GAS_CONSUMED: u8 = 0;
+pub const READ_VALUE: u8 = 1;
+
+// transaction ids
+pub const INCREMENT: u8 = 0;
+pub const DECREMENT: u8 = 1;
+
+#[derive(Clone, Canon, Debug)]
+pub struct GasConsumed {
+    junk: u32,
+    value: i32,
+}
+
+impl GasConsumed {
+    pub fn new(value: i32) -> Self {
+        GasConsumed {
+            junk: 0xffffffff,
+            value,
+        }
+    }
+}
+
+#[cfg(not(feature = "host"))]
+mod hosted {
+
+    extern crate alloc;
+
+    use super::*;
+
+    use canonical::{BridgeStore, ByteSink, ByteSource, Canon, Id32, Store};
+    use dusk_abi::{ContractState, ReturnValue};
+
+    const PAGE_SIZE: usize = 1024 * 4;
+
+    type BS = BridgeStore<Id32>;
+
+    impl GasConsumed {
+        pub fn read_value(&self) -> i32 {
+            self.value
+        }
+
+        pub fn increment(&mut self) {
+            self.value += 1;
+        }
+
+        pub fn decrement(&mut self) {
+            self.value -= 1;
+        }
+
+        pub fn gas_consumed(&self) -> u64 {
+            dusk_abi::gas_consumed()
+        }
+    }
+
+    fn query(bytes: &mut [u8; PAGE_SIZE]) -> Result<(), <BS as Store>::Error> {
+        let bs = BS::default();
+        let mut source = ByteSource::new(&bytes[..], &bs);
+
+        // read self.
+        let slf: GasConsumed = Canon::<BS>::read(&mut source)?;
+
+        // read query id
+        let qid: u8 = Canon::<BS>::read(&mut source)?;
+        match qid {
+            GAS_CONSUMED => {
+                let ret = slf.gas_consumed();
+
+                let r = {
+                    // return value
+                    let wrapped_return = ReturnValue::from_canon(&ret, &bs)?;
+
+                    let mut sink = ByteSink::new(&mut bytes[..], &bs);
+
+                    Canon::<BS>::write(&wrapped_return, &mut sink)
+                };
+
+                r
+            }
+
+            // read_value (&Self) -> i32
+            READ_VALUE => {
+                let ret = slf.read_value();
+
+                let r = {
+                    // return value
+                    let wrapped_return = ReturnValue::from_canon(&ret, &bs)?;
+
+                    dusk_abi::debug!("wrapped return {:?}", wrapped_return);
+
+                    let mut sink = ByteSink::new(&mut bytes[..], &bs);
+
+                    Canon::<BS>::write(&wrapped_return, &mut sink)
+                };
+                dusk_abi::debug!("memory bytes {:?}", &bytes[..32]);
+
+                r
+            }
+            _ => panic!(""),
+        }
+    }
+
+    #[no_mangle]
+    fn q(bytes: &mut [u8; PAGE_SIZE]) {
+        // todo, handle errors here
+        let _ = query(bytes);
+    }
+
+    fn transaction(
+        bytes: &mut [u8; PAGE_SIZE],
+    ) -> Result<(), <BS as Store>::Error> {
+        let bs = BS::default();
+        let mut source = ByteSource::new(bytes, &bs);
+
+        // read self.
+        let mut slf: GasConsumed = Canon::<BS>::read(&mut source)?;
+        // read transaction id
+        let tid: u8 = Canon::<BS>::read(&mut source)?;
+        match tid {
+            // increment (&Self)
+            INCREMENT => {
+                slf.increment();
+                let mut sink = ByteSink::new(&mut bytes[..], &bs);
+                // return new state
+                Canon::<BS>::write(
+                    &ContractState::from_canon(&slf, &bs)?,
+                    &mut sink,
+                )?;
+
+                // return value
+                Canon::<BS>::write(
+                    &ReturnValue::from_canon(&(), &bs)?,
+                    &mut sink,
+                )
+            }
+            DECREMENT => {
+                // no args
+                slf.decrement();
+                let mut sink = ByteSink::new(&mut bytes[..], &bs);
+
+                Canon::<BS>::write(
+                    &ContractState::from_canon(&slf, &bs),
+                    &mut sink,
+                )?;
+
+                // no return value
+                Ok(())
+            }
+            _ => panic!(""),
+        }
+    }
+
+    #[no_mangle]
+    fn t(bytes: &mut [u8; PAGE_SIZE]) {
+        // todo, handle errors here
+        transaction(bytes).unwrap()
+    }
+}


### PR DESCRIPTION
In dusk-network/dusk-abi#25 we introduced the
interface required so that the contracts can obtain the current
gas_consumed until a certain point of the execution.

This is needed specifically by the transfer contract as stated in #174
so that the contract can know how much Dusk the `Fee` that will be
charged to the transactor needs to contain.

To do so, this introduces the logic of the `gas_consumed` inter contract
call as well as a new contract to test that the function works as
expected.

Resolves: #174