### PR TITLE
Remove rust toolchain overrides from CI

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -11,8 +11,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: install
@@ -38,8 +36,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
       - run: rustup target add wasm32-unknown-unknown
       - run: make test
 
@@ -51,8 +47,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2020-10-25
-          override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -445,7 +445,10 @@ fn gas_consumed_host_function_works() {
         .expect("Query error");
 
     assert_eq!(gas_left + gas.spent(), 1_000_000_000,
-        "The gas left plus the gas spent should be equal to the initial gas provided");
+        "The gas left plus the gas spent should be equal to the initial gas provided
+        Debug info:
+        GasMeter values: gas.spent() = {}, gas.left() = {}
+        queried values:  gas_consumed = {}, gas_left = {}", gas.spent(), gas.left(), gas_consumed, gas_left);
 
     assert_eq!(
         gas.spent() - gas_consumed,


### PR DESCRIPTION
The test was failing because a more recent nightly was used in the CI,
instead of using the version specified in `rust-toolchain`.
Locally everything was working properly because the overrides was on the
CI config file.

Without the override both CI and local execution are using the same
version specified in `rust-toolchain`.

P.S.
Notice that on our custom runner this is not fixed since we have an additional problem that should be fixed separately – conflict with existing version of rust, looks like the runner is not properly sandboxed –, so basically trying to fix this issue there was even more complicated: in fact, even with this fix, the test is still failing on self-hosted.

Resolves: #229