### PR TITLE
Add codecov to CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+
+github_checks: false

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [ pull_request ]
 
 name: Continuous integration
 
@@ -32,12 +32,43 @@ jobs:
     name: Nightly tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-      - run: rustup target add wasm32-unknown-unknown
-      - run: make test
+
+      - name: Install WASM32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install kcov
+        run: sudo apt install -y kcov
+
+      - name: Build test contracts
+        run: make test-contracts
+
+      - name: Build test executables
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '-Cinline-threshold=0 -Clink-dead-code'
+          RUSTDOCFLAGS: '-Cinline-threshold=0 -Clink-dead-code'
+        with:
+          command: test
+          args: --all-features --no-run
+
+      - name: Test with kcov
+        # Find every executable resulting from building the tests and run each
+        # one of them with kcov. This ensures all the code we cover is measured.
+        run: >
+          find target/debug/deps -type f -executable ! -name "*.*" -exec
+          kcov --exclude-pattern=/.cargo,/usr/lib,/target,/tests --verify target/cov {} \;
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
 
   fmt:
     name: Rustfmt

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
-SUBDIRS := $(wildcard ./tests/contracts/*/.)
-
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-all: $(SUBDIRS)
+all: test-contracts
 
-test: $(SUBDIRS) ## Run the contracts' tests
+test: test-contracts ## Run the contracts' tests
 	cargo test --all-features
 
-$(SUBDIRS):
-	$(MAKE) -C $@
+test-contracts: ## Build the test contracts
+	$(MAKE) -C tests
 
-.PHONY: help all test $(SUBDIRS)
+.PHONY: help all test test-contracts

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,8 @@
+SUBDIRS := $(wildcard ./contracts/*/.)
+
+all: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@
+
+.PHONY: all $(SUBDIRS)


### PR DESCRIPTION
Adds code coverage generation to the CI, publishing it to [codecov](https://about.codecov.io).