### PR TITLE
Refactor contextual `GasMeter`

### DIFF
--- a/src/gas.rs
+++ b/src/gas.rs
@@ -7,41 +7,17 @@
 // Gas units are chosen to be represented by u64 so that gas metering
 // instructions can operate on them efficiently.
 
-use core::ops::Range;
-use core::cmp::{max, min};
-use gas_constants::*;
-
 /// Type alias for gas
 pub type Gas = u64;
 
-/// Constants for inter-contract call gas reserve calculations
-pub mod gas_constants {
-    /// Percentage of gas to be given to a callee
-    pub const GAS_RESERVE_PERCENTAGE: u64 = 93;
-    /// Constant needed for percentage calculations
-    pub const HUNDRED_PERCENT: u64 = 100;
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum GasMeterResult {
-    Proceed,
-    OutOfGas,
-}
-
-impl GasMeterResult {
-    pub const fn is_out_of_gas(&self) -> bool {
-        match *self {
-            GasMeterResult::OutOfGas => true,
-            GasMeterResult::Proceed => false,
-        }
-    }
+pub enum GasError {
+    /// Gas limit exceeded
+    GasLimitExceeded,
 }
 
 #[derive(Debug, Clone)]
 /// Struct to keep track of gas usage
 pub struct GasMeter {
-    /// Gas held but not spent yet
-    held: Gas,
     /// Initial gas limit
     limit: Gas,
     /// Amount of gas left from initial gas limit; can reach zero
@@ -49,125 +25,54 @@ pub struct GasMeter {
 }
 
 impl GasMeter {
-    /// Creates a new `GasMeter` with given gas limits
-    pub fn with_limit(gas_limit: Gas) -> GasMeter {
-        GasMeter::with_range(Range {
-            start: 0,
-            end: gas_limit,
-        })
-    }
+    /// Default percentage of gas to be given to a [`GasMeter`] when [`limited`]
+    /// is called.
+    pub const RESERVE_PERCENTAGE: u64 = 93;
 
-    /// Creates a new `GasMeter` with given gas range.
-    /// A range of `2_000..1_000_000` means that `2_000` gas will be
-    /// held for known required calculation, and therefore the gas
-    /// actually available is `1_000_000 - 2_000 = 800_000`.
-    pub fn with_range(gas_range: Range<Gas>) -> GasMeter {
-        GasMeter {
-            held: gas_range.start,
-            limit: gas_range.end,
-            left: gas_range.end,
-        }
+    /// Creates a new `GasMeter` with given gas limits
+    pub fn with_limit(limit: Gas) -> GasMeter {
+        GasMeter { limit, left: limit }
     }
 
     /// Deduct specified amount of gas from the meter
-    pub fn charge(&mut self, amount: Gas) -> GasMeterResult {
+    pub fn charge(&mut self, amount: Gas) -> Result<(), GasError> {
         match self.left.checked_sub(amount) {
+            Some(val) => {
+                self.left = val;
+                Ok(())
+            }
             // If for any reason, we fall below the threshold, we run out of gas
             // directly consuming all of the gas left.
             None => {
                 self.left = 0;
-                GasMeterResult::OutOfGas
-            }
-            // If after subtracting the gas, the gas left in the Meter is
-            // below [`GasMeter::held`]
-            // we also abort the execution since no more stuff will be
-            // possible to do.
-            Some(val) if val <= self.held => {
-                self.left = 0;
-                GasMeterResult::OutOfGas
-            }
-            Some(val) => {
-                self.left = val;
-                GasMeterResult::Proceed
+                Err(GasError::GasLimitExceeded)
             }
         }
     }
 
     /// Returns how much gas left from the initial budget.
-    #[deprecated(since = "0.6.0", note = "Please use `left` instead")]
-    pub fn gas_left(&self) -> Gas {
-        self.left
-    }
-
-    /// Returns how much gas left from the initial budget.
-    /// This take in account [`GasMeter::held`].
     pub fn left(&self) -> Gas {
-        self.left.saturating_sub(self.held)
-    }
-
-    /// Returns total number of gas left, disregarding [`GasMeter::held`].
-    pub fn total_left(&self) -> Gas {
         self.left
     }
 
     /// Returns how much gas was actually spent.
-    /// This does not consider [`GasMeter::held`] since it's not spent yet.
     pub fn spent(&self) -> Gas {
         self.limit - self.left
     }
 
-    fn clone_for_callee_default(&self) -> GasMeter {
-        let new_held = if self.left > self.held {
-            self.held
-                + ((self.left - self.held)
-                    * (HUNDRED_PERCENT - GAS_RESERVE_PERCENTAGE)
-                    / HUNDRED_PERCENT)
+    /// Create a new limited [`GasMeter`].
+    /// If `limit` parameter is `0`, default limit is assumed that satisfies
+    /// the requirement for obligatory gas reserve ([`Self::RESERVE_PERCENTAGE`]
+    /// of the gas left).
+    /// The limit provided cannot exceed the gas left, if that happens the
+    /// total amount of gas is used as limit.
+    pub fn limited(&self, limit: Gas) -> GasMeter {
+        let limit = if limit == 0 {
+            self.left() * Self::RESERVE_PERCENTAGE / 100
         } else {
-            self.held
+            core::cmp::min(limit, self.left())
         };
-        GasMeter {
-            held: new_held,
-            limit: self.left,
-            left: self.left,
-        }
-    }
 
-    fn clone_for_callee_with_limit(&self, limit: Gas) -> GasMeter {
-        let new_held = max(self.left.saturating_sub(limit), self.held);
-        GasMeter {
-            held: new_held,
-            limit: self.left,
-            left: self.left,
-        }
-    }
-
-    /// Clones gas meter for the use by a callee, modifying its held field
-    /// so that it satisfies a limit parameter is given.
-    /// If limit parameter is none, default limit is assumed that satisfies
-    /// the requirement for obligatory gas reserve.
-    /// Held field is set to the following value:
-    ///     If limit is given:
-    ///         held = this_left - limit
-    ///     If limit is not given:
-    ///         held = this_held + (this_left - this_held) *
-    ///             (100 - GAS_RESERVE_PERCENTAGE) / 100
-    /// Limit field is set to the following value:
-    ///     (For both limit given or default):
-    ///         limit = this_left
-    pub fn clone_for_callee(&self, limit_option: Option<Gas>) -> GasMeter {
-        match limit_option {
-            Some(limit) => self.clone_for_callee_with_limit(limit),
-            None => self.clone_for_callee_default(),
-        }
-    }
-
-    /// Merges this gas meter with a gas meter obtained from a finished callee.
-    /// It updates the 'left' field value from the callee.
-    /// Update is only done if callee's 'left' field value is higher that this
-    /// gas meter 'left' value.
-    /// Fields limit and held are not changed as the are local for every
-    /// gas context - they propagate up the stack but never down the stack.
-    pub fn merge_with_callee(&mut self, callee_gas_meter: &GasMeter) {
-        self.left = min(callee_gas_meter.left, self.left);
+        GasMeter { limit, left: limit }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,13 @@ mod state;
 pub use dusk_abi;
 
 pub use contract::{Contract, ContractId};
-pub use gas::{Gas, GasMeter, gas_constants};
+pub use gas::{Gas, GasMeter};
 pub use state::NetworkState;
 
 use thiserror::Error;
 use wasmer_vm::TrapCode;
 
 #[derive(Error)]
-//#[derive(Fail)]
 /// The errors that can happen while executing the VM
 pub enum VMError {
     /// Invalid arguments in host call
@@ -95,6 +94,13 @@ impl From<io::Error> for VMError {
 impl From<module_config::InstrumentationError> for VMError {
     fn from(e: module_config::InstrumentationError) -> Self {
         VMError::InstrumentationError(e)
+    }
+}
+
+impl From<gas::GasError> for VMError {
+    fn from(_: gas::GasError) -> Self {
+        // Currently the only gas error is `GasLimitExceeded`
+        VMError::OutOfGas
     }
 }
 

--- a/src/ops/gas.rs
+++ b/src/ops/gas.rs
@@ -14,9 +14,7 @@ impl Gas {
     pub fn gas(env: &Env, gas_charged: i32) -> Result<(), VMError> {
         let context = env.get_context();
         let meter = context.gas_meter_mut();
-        if meter.charge(gas_charged as u64).is_out_of_gas() {
-            return Err(VMError::OutOfGas);
-        }
+        meter.charge(gas_charged as u64)?;
         Ok(())
     }
 }

--- a/src/ops/query.rs
+++ b/src/ops/query.rs
@@ -31,7 +31,8 @@ impl ExecuteQuery {
         let query =
             Query::decode(&mut source).map_err(VMError::from_store_error)?;
 
-        let result = context.query(contract_id, query, gas_limit)?;
+        let mut gas_meter = context.gas_meter().limited(gas_limit);
+        let result = context.query(contract_id, query, &mut gas_meter)?;
 
         let mut result_buffer = vec![0; result.encoded_len()];
         let mut sink = Sink::new(&mut result_buffer[..]);

--- a/src/ops/transact.rs
+++ b/src/ops/transact.rs
@@ -38,8 +38,9 @@ impl ApplyTransaction {
         let callee = *context.callee();
         *context.state_mut().get_contract_mut(&callee)?.state_mut() = state;
 
+        let mut gas_meter = context.gas_meter().limited(gas_limit);
         let (state, result) =
-            context.transact(contract_id, transaction, gas_limit)?;
+            context.transact(contract_id, transaction, &mut gas_meter)?;
 
         let state_encoded_length = state.encoded_len();
         let (mut state_buffer, mut result_buffer) =

--- a/src/state.rs
+++ b/src/state.rs
@@ -62,7 +62,8 @@ impl Canon for NetworkState {
 
 #[cached(size = 2048, time = 86400, result = true, sync_writes = true)]
 fn get_or_create_module(bytecode: Vec<u8>) -> Result<Module, VMError> {
-    Ok(WasmerCompiler::create_module(bytecode)?)
+    let new_module = WasmerCompiler::create_module(bytecode)?;
+    Ok(new_module)
 }
 
 impl NetworkState {
@@ -166,11 +167,10 @@ impl NetworkState {
         A: Canon,
         R: Canon,
     {
-        let gas_left = gas_meter.left();
-        let mut context = CallContext::new(self, gas_meter);
+        let mut context = CallContext::new(self);
 
         let result =
-            context.query(target, Query::from_canon(&query), gas_left)?;
+            context.query(target, Query::from_canon(&query), gas_meter)?;
 
         result.cast().map_err(VMError::from_store_error)
     }
@@ -189,14 +189,13 @@ impl NetworkState {
         // Fork the current network's state
         let mut fork = self.clone();
 
-        let gas_left = gas_meter.left();
         // Use the forked state to execute the transaction
-        let mut context = CallContext::new(&mut fork, gas_meter);
+        let mut context = CallContext::new(&mut fork);
 
         let (_, result) = context.transact(
             target,
             Transaction::from_canon(&transaction),
-            gas_left,
+            gas_meter,
         )?;
 
         let ret = result.cast().map_err(VMError::from_store_error)?;

--- a/tests/contracts/gas_context/src/lib.rs
+++ b/tests/contracts/gas_context/src/lib.rs
@@ -17,7 +17,7 @@ pub const SET_GAS_LIMITS: u8 = 1;
 // query ids
 pub const READ_GAS_LIMITS: u8 = 1;
 
-#[derive(Clone, Canon, Debug)]
+#[derive(Clone, Canon, Debug, Default)]
 pub struct GasContextData {
     after_call_gas_limits: Vec<u64>,
     call_gas_limits: Vec<u64>,

--- a/tests/gas_context.rs
+++ b/tests/gas_context.rs
@@ -4,9 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use gas_constants::*;
 use gas_context::GasContextData;
-use rusk_vm::{gas_constants, Contract, Gas, GasMeter, NetworkState};
+use rusk_vm::{Contract, Gas, GasMeter, NetworkState};
 
 #[test]
 fn gas_context() {
@@ -24,9 +23,10 @@ fn gas_context() {
 
     const INITIAL_GAS_LIMIT: Gas = 1_000_000_000;
     const GAS_RESERVE_TOLERANCE_PERCENTAGE: u64 = 1;
-    const GAS_RESERVE_UPPER_BOUND_PERCENTAGE: u64 = GAS_RESERVE_PERCENTAGE;
+    const GAS_RESERVE_UPPER_BOUND_PERCENTAGE: u64 =
+        GasMeter::RESERVE_PERCENTAGE;
     const GAS_RESERVE_LOWER_BOUND_PERCENTAGE: u64 =
-        GAS_RESERVE_PERCENTAGE - GAS_RESERVE_TOLERANCE_PERCENTAGE;
+        GasMeter::RESERVE_PERCENTAGE - GAS_RESERVE_TOLERANCE_PERCENTAGE;
     const NUMBER_OF_NESTED_CALLS: usize = 10;
 
     let mut gas = GasMeter::with_limit(INITIAL_GAS_LIMIT);
@@ -61,17 +61,15 @@ fn gas_context() {
         .iter()
         .map(|limit| {
             (
-                *limit * GAS_RESERVE_LOWER_BOUND_PERCENTAGE / HUNDRED_PERCENT,
-                *limit * GAS_RESERVE_UPPER_BOUND_PERCENTAGE / HUNDRED_PERCENT,
+                *limit * GAS_RESERVE_LOWER_BOUND_PERCENTAGE / 100,
+                *limit * GAS_RESERVE_UPPER_BOUND_PERCENTAGE / 100,
             )
         })
         .collect();
     bounds.insert(
         0,
         (
-            INITIAL_GAS_LIMIT
-                * (HUNDRED_PERCENT - GAS_RESERVE_TOLERANCE_PERCENTAGE)
-                / HUNDRED_PERCENT,
+            INITIAL_GAS_LIMIT * (100 - GAS_RESERVE_TOLERANCE_PERCENTAGE) / 100,
             INITIAL_GAS_LIMIT,
         ),
     );


### PR DESCRIPTION
- Add `GasMeter::RESERVE_PERCENTAGE` as associated constant
- Add `GasMeter::limited` method
- Add mutable `GasMeter` reference to `StackFrame`
- Add `StackFrame::new` associated function
- Remove `Argument` field from `StackFrame`
- Remove `StackFrame::new_query` and `StackFrame::new_transaction`
- Remove `GasMeter` from `CallContext`
- Remove `GasMeter.held` private field
- Remove `GasMeter::with_range` associated function
- Remove `gas_constants` module
- Replace `GasMeterResult` with `GasError`
- Remove `GasMeter::gas_left` method, deprecated since 0.6
- Remove `GasMeter::total_left` method
- Remove `GasMeter::clone_for_callee_default` method
- Remove `GasMeter::clone_for_callee` method
- Remove `GasMeter::merge_with_callee` method
- Updated tests

Resolves: #254