### PR TITLE
Make stackframe pure functional

### DIFF
--- a/src/call_context.rs
+++ b/src/call_context.rs
@@ -138,7 +138,8 @@ impl<'a> CallContext<'a> {
                 query.as_bytes(),
             )?;
 
-            self.stack.push(StackFrame::new(target, memory, gas_meter.clone()));
+            self.stack
+                .push(StackFrame::new(target, memory, gas_meter.clone()));
         }
 
         let run_func: NativeFunc<i32, ()> =

--- a/src/call_context.rs
+++ b/src/call_context.rs
@@ -295,7 +295,10 @@ impl<'a> CallContext<'a> {
     }
 
     /// Reconcile the gas usage across the stack.
-    fn gas_reconciliation(&mut self, gas_meter: &mut GasMeter) -> Result<(), VMError> {
+    fn gas_reconciliation(
+        &mut self,
+        gas_meter: &mut GasMeter,
+    ) -> Result<(), VMError> {
         // If there is more than one [`StackFrame`] on the stack, then the
         // gas needs to be reconciled.
         if self.stack.len() > 1 {

--- a/src/call_context.rs
+++ b/src/call_context.rs
@@ -138,7 +138,7 @@ impl<'a> CallContext<'a> {
                 query.as_bytes(),
             )?;
 
-            self.stack.push(StackFrame::new(target, memory, *gas_meter));
+            self.stack.push(StackFrame::new(target, memory, gas_meter.clone()));
         }
 
         let run_func: NativeFunc<i32, ()> =
@@ -202,7 +202,7 @@ impl<'a> CallContext<'a> {
             self.stack.push(StackFrame::new(
                 target_contract_id,
                 memory,
-                *gas_meter,
+                gas_meter.clone(),
             ));
         }
 
@@ -308,7 +308,7 @@ impl<'a> CallContext<'a> {
 
             parent_meter.charge(spent)?
         }
-        *gas_meter = *self.gas_meter();
+        *gas_meter = self.gas_meter().clone();
 
         Ok(())
     }

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -15,7 +15,7 @@ pub enum GasError {
     GasLimitExceeded,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 /// Struct to keep track of gas usage
 pub struct GasMeter {
     /// Initial gas limit

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -15,7 +15,7 @@ pub enum GasError {
     GasLimitExceeded,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 /// Struct to keep track of gas usage
 pub struct GasMeter {
     /// Initial gas limit


### PR DESCRIPTION
It is a proposal to make stack frame pure functional, i.e., not having references. This make reasoning about stack frame much easier as there are no side effects when dealing with it and all effects needs to be explicit.
It addresses the issue: 
https://github.com/dusk-network/rusk-vm/issues/254