### PR TITLE
Support TX rollbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add support for transaction rollbacks [#263]
 - Add cache for `wasmer` modules [#251]
 - Add `wasmer` instrumentation [#247]
 - Add CHANGELOG [#236]
@@ -185,6 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#270]: https://github.com/dusk-network/rusk-vm/issues/270
 [#269]: https://github.com/dusk-network/rusk-vm/issues/269
+[#263]: https://github.com/dusk-network/rusk-vm/issues/263
 [#251]: https://github.com/dusk-network/rusk-vm/issues/251
 [#248]: https://github.com/dusk-network/rusk-vm/issues/248
 [#247]: https://github.com/dusk-network/rusk-vm/issues/247

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>",
   "Milosz Muszynski <milosz@dusk.network>",
+  "Eduardo Leegwater Simões <eduardo@dusk.network>",
 ]
 edition = "2018"
 repository = "https://github.com/dusk-network/rusk-vm"

--- a/src/call_context.rs
+++ b/src/call_context.rs
@@ -14,7 +14,7 @@ use crate::gas::GasMeter;
 use crate::memory::WasmerMemory;
 use crate::modules::compile_module;
 use crate::resolver::HostImportsResolver;
-use crate::state::NetworkState;
+use crate::state::{Contracts, NetworkState};
 use crate::VMError;
 
 pub struct StackFrame {
@@ -290,8 +290,8 @@ impl<'a> CallContext<'a> {
         Ok(())
     }
 
-    pub fn state_mut(&mut self) -> &mut NetworkState {
-        &mut self.state
+    pub fn state_mut(&mut self) -> &mut Contracts {
+        self.state.head_mut()
     }
 
     /// Reconcile the gas usage across the stack.

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -25,8 +25,8 @@ pub struct GasMeter {
 }
 
 impl GasMeter {
-    /// Default percentage of gas to be given to a [`GasMeter`] when [`limited`]
-    /// is called.
+    /// Default percentage of gas to be given to a [`GasMeter`] when
+    /// [`limited`](`Self::limited`) is called.
     pub const RESERVE_PERCENTAGE: u64 = 93;
 
     /// Creates a new `GasMeter` with given gas limits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ pub struct Schedule {
 
     /// Maximum allowed stack height.
     ///
-    /// See https://wiki.parity.io/WebAssembly-StackHeight to find out
+    /// See `<https://wiki.parity.io/WebAssembly-StackHeight>` to find out
     /// how the stack frame cost is calculated.
     pub max_stack_height: u32,
 


### PR DESCRIPTION
This PR is intended to address the transaction rollbacks problem described in #263.

The change entails keeping two states in memory - the `origin` and the `head` state. The caller can choose to perform queries or transactions on either, and the result of transactions will is kept in the `head` state.

When the user deems that enough transactions have been performed on the state they can call `commit` to copy the `head` into the origin.

If the users finds that for some reason they want to discard the state, they can call `reset` to copy `origin` into `head`.