### PR TITLE
Wrap `NetworkState::modules`' type in a struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `deploy_with_id` method to NetworkState [#210]
 
 ### Changed
+- Wrap `NetworkState::modules` in `HostModules` struct [#270]
 - Port from `wasmi` to `wasmer` [#245]
 - Update dependencies
 
@@ -182,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2019-08-02
 - Initial
 
+[#270]: https://github.com/dusk-network/rusk-vm/issues/270
 [#269]: https://github.com/dusk-network/rusk-vm/issues/269
 [#251]: https://github.com/dusk-network/rusk-vm/issues/251
 [#248]: https://github.com/dusk-network/rusk-vm/issues/248

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::module_config::ModuleConfig;
+use crate::modules::ModuleConfig;
 use crate::VMError;
 use canonical::Canon;
 use canonical_derive::Canon;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod contract;
 mod env;
 mod gas;
 mod memory;
-mod module_config;
+mod modules;
 mod ops;
 mod resolver;
 mod state;
@@ -44,7 +44,7 @@ pub enum VMError {
     /// Could not find WASM memory
     MemoryNotFound,
     /// Error during the instrumentalization
-    InstrumentationError(module_config::InstrumentationError),
+    InstrumentationError(modules::InstrumentationError),
     /// Invalid ABI Call
     InvalidABICall,
     /// Invalid Utf8
@@ -91,8 +91,8 @@ impl From<io::Error> for VMError {
     }
 }
 
-impl From<module_config::InstrumentationError> for VMError {
-    fn from(e: module_config::InstrumentationError) -> Self {
+impl From<modules::InstrumentationError> for VMError {
+    fn from(e: modules::InstrumentationError) -> Self {
         VMError::InstrumentationError(e)
     }
 }


### PR DESCRIPTION
Wraps the type of the `NetworkState::modules` field in the `HostModules` structure.

Resolves: #270