### PR TITLE
Add support for reading the state root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Enable reading the state root [#265]
 - Add log tracing for easier debugging [#83]
 - Add support for transaction rollbacks [#263]
 - Add cache for `wasmer` modules [#251]
@@ -187,6 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#270]: https://github.com/dusk-network/rusk-vm/issues/270
 [#269]: https://github.com/dusk-network/rusk-vm/issues/269
+[#265]: https://github.com/dusk-network/rusk-vm/issues/265
 [#263]: https://github.com/dusk-network/rusk-vm/issues/263
 [#251]: https://github.com/dusk-network/rusk-vm/issues/251
 [#248]: https://github.com/dusk-network/rusk-vm/issues/248

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,7 +6,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use canonical::{Canon, CanonError, Sink, Source, Store};
+use canonical::{Canon, CanonError, EncodeToVec, Sink, Source, Store};
 use canonical_derive::Canon;
 use dusk_abi::{HostModule, Query, Transaction};
 use dusk_hamt::Map;
@@ -59,6 +59,13 @@ impl Contracts {
     ) -> Result<ContractId, VMError> {
         let id: ContractId = Store::hash(contract.bytecode()).into();
         self.deploy_with_id(id, contract)
+    }
+
+    /// Computes the root of the contracts tree.
+    pub fn root(&self) -> [u8; 32] {
+        // FIXME This is terribly slow. It should be possible to get it directly
+        //  from the tree. https://github.com/dusk-network/microkelvin/issues/85
+        Store::hash(&self.0.encode_to_vec())
     }
 
     /// Deploys a contract with the given id to the state.
@@ -284,6 +291,11 @@ impl NetworkState {
         *self = fork;
 
         Ok(ret)
+    }
+
+    /// Returns the root of the tree in the `head` state.
+    pub fn root(&self) -> [u8; 32] {
+        self.head.root()
     }
 
     /// Resets the `head` state to `origin`.


### PR DESCRIPTION
The implementation is currently very slow. Making it faster is contingent on microkelvin allowing for a direct [query of the root](https://github.com/dusk-network/microkelvin/issues/85).

Resolves: #265