### PR TITLE
Bump to `v0.7.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2022-01-19
+
 ### Added
 
 - Add capability of reading the state root [#265]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-vm"
-version = "0.7.0-rc.3"
+version = "0.7.0"
 authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>",


### PR DESCRIPTION
- Update CHANGELOG.md

**Note**
Due the incoming breaking changes, the release candidate of 0.7 should be published, so we can move to `0.8`.
This PR is to prepare the library to be published in crates.io