### PR TITLE
Release 0.11.0-rc.0 with Gas fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `staged` state in addition to the existing `head` and `origin` [#302]
 - Add `unstage` method to remove changes from `staged` [#302]
 - Add `push` method to push the commited changes to `origin` [#302]
+- Add `exhaust` method to `GasMeter` [#308]
+- Add a private `update` method to `GasMeter` [#308]
+- Add `VMError::EmptyStack` [#308]
+- Add `Instance` field to `StackFrame` [#308]
+- Add `CallContext::top_mut()` [#308]
+- Add new `CallContext::gas_meter` method in `ops` module
 
 ### Changed
 
 - Change `commit` method to commit the changes from `staged` to `head` [#302]
 - Change `register_host_module` to be an associated function
+- Replace `GasMeter::set_left(0)` with `GasMeter::exhaust()` [#308]
+- Change `CallContext::top()` to return a `Result` [#308]
+- Change `CallContext::gas_meter()` to update the gas meter before return it [#308]
+
+### Removed
+
+- Remove `set_left` method from `GasMeter` [#308]
+- Remove legacy `gas` host function
+- Remove `CallContext::gas_meter_mut()` [#308]
+- Remove `Gas` host function implementation from `ops` module
 
 ## [0.9.0] - 2022-02-02
 
@@ -265,6 +281,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial
 
+[#308]: https://github.com/dusk-network/rusk-vm/issues/308
 [#302]: https://github.com/dusk-network/rusk-vm/issues/302
 [#283]: https://github.com/dusk-network/rusk-vm/issues/283
 [#270]: https://github.com/dusk-network/rusk-vm/issues/270

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-vm"
-version = "0.10.0-rc.0"
+version = "0.11.0-rc.0"
 authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ use wasmer_vm::TrapCode;
 pub enum VMError {
     /// Invalid arguments in host call
     InvalidArguments,
+    /// The Stack is empty
+    EmptyStack,
     /// The contract panicked with message in `String`
     ContractPanic(String),
     /// Could not find WASM memory
@@ -150,6 +152,7 @@ impl fmt::Display for VMError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             VMError::InvalidArguments => write!(f, "Invalid arguments")?,
+            VMError::EmptyStack => write!(f, "The stack is empty")?,
             VMError::ContractPanic(string) => {
                 write!(f, "Contract panic \"{}\"", string)?
             }

--- a/src/ops/call_stack.rs
+++ b/src/ops/call_stack.rs
@@ -17,7 +17,7 @@ impl Callee {
 
         let result_ofs = result_ofs as usize;
         let context = env.get_context();
-        let callee = *context.callee();
+        let callee = *context.callee()?;
 
         context.write_memory(callee.as_bytes(), result_ofs as u64)
     }
@@ -31,7 +31,7 @@ impl Caller {
 
         let result_ofs = result_ofs as usize;
         let context = env.get_context();
-        let caller = *context.caller();
+        let caller = *context.caller()?;
 
         context.write_memory(caller.as_bytes(), result_ofs as u64)
     }

--- a/src/ops/gas.rs
+++ b/src/ops/gas.rs
@@ -9,32 +9,15 @@ use tracing::trace;
 use crate::env::Env;
 use crate::VMError;
 
-pub struct Gas;
-
-impl Gas {
-    pub fn gas(env: &Env, gas_charged: i32) -> Result<(), VMError> {
-        let context = env.get_context();
-        let meter = context.gas_meter_mut();
-        meter.charge(gas_charged as u64)?;
-        Ok(())
-    }
-}
-
 pub struct GasConsumed;
-
-impl GasConsumed {
-    pub const GAS_CONSUMED_CALL_COST: u64 = 1;
-}
 
 impl GasConsumed {
     pub fn gas_consumed(env: &Env) -> Result<u64, VMError> {
         trace!("Executing 'gas_consumed' host function");
 
         let context = env.get_context();
-        // FIXME: This will not always be correct since if the `gas_consumed =
-        // ALL` the gas, this will add the extra cost of the call
-        // which can't be consumed since it's not even there.
-        Ok(context.gas_meter().spent() + GasConsumed::GAS_CONSUMED_CALL_COST)
+
+        Ok(context.gas_meter()?.spent())
     }
 }
 
@@ -45,6 +28,7 @@ impl GasLeft {
         trace!("Executing 'gas_left' host function");
 
         let context = env.get_context();
-        Ok(context.gas_meter().left())
+
+        Ok(context.gas_meter()?.left())
     }
 }

--- a/src/ops/query.rs
+++ b/src/ops/query.rs
@@ -34,7 +34,7 @@ impl ExecuteQuery {
         let query =
             Query::decode(&mut source).map_err(VMError::from_store_error)?;
 
-        let mut gas_meter = context.gas_meter().limited(gas_limit);
+        let mut gas_meter = context.gas_meter()?.limited(gas_limit);
         let result = context.query(contract_id, query, &mut gas_meter)?;
 
         let mut result_buffer = vec![0; result.encoded_len()];

--- a/src/ops/transact.rs
+++ b/src/ops/transact.rs
@@ -38,10 +38,10 @@ impl ApplyTransaction {
         let transaction = Transaction::decode(&mut source)
             .map_err(VMError::from_store_error)?;
 
-        let callee = *context.callee();
+        let callee = *context.callee()?;
         *context.state_mut().get_contract_mut(&callee)?.state_mut() = state;
 
-        let mut gas_meter = context.gas_meter().limited(gas_limit);
+        let mut gas_meter = context.gas_meter()?.limited(gas_limit);
         let (state, result) =
             context.transact(contract_id, transaction, &mut gas_meter)?;
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -100,14 +100,6 @@ impl HostImportsResolver {
                         store::Hash::hash,
                     ),
                 ),
-                "gas" => namespace.insert(
-                    "gas",
-                    Function::new_native_with_env(
-                        store,
-                        env.clone(),
-                        gas::Gas::gas,
-                    ),
-                ),
                 "gas_consumed" => namespace.insert(
                     "gas_consumed",
                     Function::new_native_with_env(

--- a/tests/contracts/gas_consumed/src/lib.rs
+++ b/tests/contracts/gas_consumed/src/lib.rs
@@ -65,9 +65,27 @@ mod hosted {
                 Ok(())
             }
             GAS_CONSUMED => {
-                let ret = (dusk_abi::gas_consumed(), dusk_abi::gas_left());
+                let mut ret = (
+                    dusk_abi::gas_consumed(),
+                    dusk_abi::gas_left(),
+                    0,
+                    0,
+                    0,
+                    0,
+                );
 
                 let mut sink = Sink::new(&mut bytes[..]);
+
+                let gas_consumed_before = dusk_abi::gas_consumed();
+                let gas_left_before = dusk_abi::gas_left();
+                let x = 5i32;
+                let _y = x.pow(5);
+                let gas_consumed_after = dusk_abi::gas_consumed();
+                let gas_left_after = dusk_abi::gas_left();
+                ret.2 = gas_consumed_before as u64;
+                ret.3 = gas_consumed_after as u64;
+                ret.4 = gas_left_before as u64;
+                ret.5 = gas_left_after as u64;
 
                 ReturnValue::from_canon(&ret).encode(&mut sink);
                 Ok(())

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -460,8 +460,8 @@ fn gas_consumed_host_function_works() {
         100
     );
 
-    network
-        .query::<_, (u64, u64)>(
+    let ret = network
+        .query::<_, (u64, u64, u64, u64, u64, u64)>(
             contract_id,
             0,
             gas_consumed::GAS_CONSUMED,
@@ -473,6 +473,14 @@ fn gas_consumed_host_function_works() {
                "The gas left plus the gas spent should be equal to the initial gas provided
         Debug info:
         GasMeter values: gas.left() = {}, gas.spent() = {}", gas.left(), gas.spent());
+
+    let gas_consumption_before = ret.2;
+    let gas_consumption_after = ret.3;
+    assert_ne!(gas_consumption_before, gas_consumption_after);
+
+    let gas_left_before = ret.4;
+    let gas_left_after = ret.5;
+    assert_ne!(gas_left_before, gas_left_after);
 }
 
 #[test]


### PR DESCRIPTION
### Added

- Add `exhaust` method to `GasMeter`
- Add a private `update` method to `GasMeter`
- Add `VMError::EmptyStack`
- Add `Instance` field to `StackFrame` 
- Add `CallContext::top_mut()`
- Add new `CallContext::gas_meter` method in `ops` module
 
 ### Changed
 
- Replace `GasMeter::set_left(0)` with `GasMeter::exhaust()` 
- Change `CallContext::top()` to return a `Result`
- Change `CallContext::gas_meter()` to update the gas meter before return it

### Removed

- Remove `set_left` method from `GasMeter` 
- Remove legacy `gas` host function
- Remove `CallContext::gas_meter_mut()`
- Remove `Gas` host function implementation from `ops` module
 
Resolves #308