### PR TITLE
Add simple dusk-hamt test to the test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ callee_2 = { path = "tests/contracts/callee-2" }
 gas_consumed = { path = "tests/contracts/gas_consumed" }
 counter_float = { path = "tests/contracts/counter_float" }
 gas_context = { path = "tests/contracts/gas_context" }
+map = { path = "tests/contracts/map" }
 
 [[bench]]
 name = "fibonacci"

--- a/tests/contracts/map/Cargo.toml
+++ b/tests/contracts/map/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "map"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+canonical = "0.6"
+canonical_derive = "0.6"
+
+dusk-hamt = "0.9"
+dusk-abi = "0.10"

--- a/tests/contracts/map/Makefile
+++ b/tests/contracts/map/Makefile
@@ -1,0 +1,6 @@
+all: ## Generate the optimized WASM for the contract given
+	@cargo rustc \
+		--manifest-path=./Cargo.toml \
+		--release \
+		--target wasm32-unknown-unknown \
+		-- -C link-args=-s

--- a/tests/contracts/map/rustfmt.toml
+++ b/tests/contracts/map/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 80
+wrap_comments = true

--- a/tests/contracts/map/src/lib.rs
+++ b/tests/contracts/map/src/lib.rs
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+#![cfg_attr(target_arch = "wasm32", no_std)]
+#![feature(core_intrinsics, lang_items, alloc_error_handler)]
+
+use canonical::CanonError;
+use canonical_derive::Canon;
+
+// transaction ids
+pub const SET: u8 = 0;
+pub const REMOVE: u8 = 1;
+
+// query ids
+pub const GET: u8 = 1;
+
+#[derive(Clone, Canon, Debug, Default)]
+pub struct Map {
+    inner: dusk_hamt::Map<u8, u32>,
+}
+
+impl Map {
+    pub fn new() -> Self {
+        Map {
+            inner: dusk_hamt::Map::default(),
+        }
+    }
+
+    pub fn set(&mut self, key: u8, value: u32) -> Option<u32> {
+        self.inner.insert(key, value).ok()?
+    }
+
+    pub fn get(&self, key: &u8) -> Option<u32> {
+        self.inner.get(key).map(|x| x.map(|x| *x)).ok()?
+    }
+
+    pub fn remove(&mut self, key: &u8) -> Result<Option<u32>, CanonError> {
+        self.inner.remove(key)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod hosted {
+    use super::*;
+
+    use canonical::{Canon, CanonError, Sink, Source};
+    use dusk_abi::{ContractState, ReturnValue};
+
+    const PAGE_SIZE: usize = 1024 * 64;
+
+    fn query(bytes: &mut [u8; PAGE_SIZE]) -> Result<(), CanonError> {
+        let mut source = Source::new(&bytes[..]);
+
+        // read self.
+        let slf = Map::decode(&mut source)?;
+
+        // read query id
+        let qid = u8::decode(&mut source)?;
+        match qid {
+            GET => {
+                let key = u8::decode(&mut source)?;
+                let ret = slf.get(&key);
+
+                let mut sink = Sink::new(&mut bytes[..]);
+
+                ReturnValue::from_canon(&ret).encode(&mut sink);
+                Ok(())
+            }
+            _ => panic!(""),
+        }
+    }
+
+    #[no_mangle]
+    fn q(bytes: &mut [u8; PAGE_SIZE]) {
+        // todo, handle errors here
+        let _ = query(bytes);
+    }
+
+    fn transaction(bytes: &mut [u8; PAGE_SIZE]) -> Result<(), CanonError> {
+        let mut source = Source::new(bytes);
+
+        // read self.
+        let mut slf = Map::decode(&mut source)?;
+        // read transaction id
+        let tid = u8::decode(&mut source)?;
+        match tid {
+            SET => {
+                let key = u8::decode(&mut source)?;
+                let value = u32::decode(&mut source)?;
+                let result = slf.set(key, value);
+
+                let mut sink = Sink::new(&mut bytes[..]);
+
+                ContractState::from_canon(&slf).encode(&mut sink);
+                ReturnValue::from_canon(&result).encode(&mut sink);
+
+                Ok(())
+            }
+            REMOVE => {
+                let key = u8::decode(&mut source)?;
+                let result = slf.remove(&key);
+
+                let mut sink = Sink::new(&mut bytes[..]);
+
+                ContractState::from_canon(&slf).encode(&mut sink);
+                ReturnValue::from_canon(&result).encode(&mut sink);
+                Ok(())
+            }
+            _ => panic!(""),
+        }
+    }
+
+    #[no_mangle]
+    fn t(bytes: &mut [u8; PAGE_SIZE]) {
+        // todo, handle errors here
+        let _ = transaction(bytes);
+    }
+}


### PR DESCRIPTION
This test is added to ensure that `dusk-hamt` can be compiled and used properly in `wasm32` target architecture.