### PR TITLE
Improve VMError Implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusk-vm"
-version = "0.11.0-rc.1"
+version = "0.12.0-rc.0"
 authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>",

--- a/src/call_context.rs
+++ b/src/call_context.rs
@@ -121,12 +121,12 @@ impl<'a> CallContext<'a> {
 
         if let Some(module) = HOST_MODULES.read().get_module(&target) {
             // is this a reserved module call?
-            return module.execute(query).map_err(VMError::from_store_error);
+            return Ok(module.execute(query)?);
         } else {
             let contract = self.state.get_contract(&target)?;
 
             let module = compile_module(
-                &**contract.bytecode().map_err(VMError::from_store_error)?,
+                &**contract.bytecode()?,
                 self.state.get_module_config(),
             )?;
 
@@ -187,8 +187,7 @@ impl<'a> CallContext<'a> {
         memory.init(&instance.exports)?;
         let read_buffer = memory.read_from(0)?;
         let mut source = Source::new(read_buffer);
-        let result = ReturnValue::decode(&mut source)
-            .map_err(VMError::from_store_error)?;
+        let result = ReturnValue::decode(&mut source)?;
         self.stack.pop();
         Ok(result)
     }
@@ -214,7 +213,7 @@ impl<'a> CallContext<'a> {
             let contract = self.state.get_contract(&target)?;
 
             let module = compile_module(
-                &**contract.bytecode().map_err(VMError::from_store_error)?,
+                &**contract.bytecode()?,
                 self.state.get_module_config(),
             )?;
 
@@ -275,11 +274,9 @@ impl<'a> CallContext<'a> {
             memory.init(&instance.exports)?;
             let read_buffer = memory.read_from(0)?;
             let mut source = Source::new(read_buffer);
-            let state = ContractState::decode(&mut source)
-                .map_err(VMError::from_store_error)?;
+            let state = ContractState::decode(&mut source)?;
             *(*contract).state_mut() = state;
-            ReturnValue::decode(&mut source)
-                .map_err(VMError::from_store_error)?
+            ReturnValue::decode(&mut source)?
         };
 
         let state = if self.stack.len() > 1 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::gas;
+use crate::modules;
+
+use canonical::CanonError;
+use dusk_abi::ContractId;
+use std::io;
+use thiserror::Error;
+use wasmer_vm::TrapCode;
+
+#[derive(Error, Debug)]
+/// The errors that can happen while executing the VM
+pub enum VMError {
+    /// The Stack is empty
+    #[error("The Stack is empty")]
+    EmptyStack,
+    /// The Contract Panicked
+    #[error("The contract {0} panicked with message: {1}")]
+    ContractPanic(ContractId, String),
+    /// Instrumentation Error
+    #[error(transparent)]
+    InstrumentationError(#[from] modules::InstrumentationError),
+    /// Invalid UTF-8
+    #[error("Invalid UTF-8")]
+    InvalidUtf8,
+    /// Contract execution ran out of gas
+    #[error("Contract execution ran out of gas")]
+    OutOfGas,
+    /// Contract could not be found in the state
+    #[error("Contract {0} could not be found in the state")]
+    UnknownContract(ContractId),
+    /// Input / Output error
+    #[error("Input / Output error")]
+    IOError(#[from] io::Error),
+    /// Error propagated from underlying store
+    #[error("Error propagated from underlying store")]
+    StoreError(CanonError),
+    /// WASMER export error
+    #[error(transparent)]
+    WasmerExportError(#[from] wasmer::ExportError),
+    /// WASMER runtime error
+    #[error(transparent)]
+    WasmerRuntimeError(wasmer::RuntimeError),
+    /// WASMER  compile error
+    #[error(transparent)]
+    WasmerCompileError(#[from] wasmer::CompileError),
+    /// WASMER instantiation error
+    #[error(transparent)]
+    WasmerInstantiationError(#[from] wasmer::InstantiationError),
+    /// WASMER trap
+    #[error("WASMER trap")]
+    WasmerTrap(TrapCode),
+}
+
+impl From<gas::GasError> for VMError {
+    fn from(_: gas::GasError) -> Self {
+        // Currently the only gas error is `GasLimitExceeded`
+        VMError::OutOfGas
+    }
+}
+
+impl From<wasmer::RuntimeError> for VMError {
+    fn from(e: wasmer::RuntimeError) -> Self {
+        // NOTE: Do not clone before downcasting!
+        // `RuntimeError::downcast` calls `Arc::try_unwrap` which will fail to
+        // downcast if there is more than one reference to the `Arc`.
+        let e = match e.downcast::<VMError>() {
+            Ok(vm_error) => return vm_error,
+            Err(err) => err,
+        };
+
+        match e.clone().to_trap() {
+            Some(trap_code) => VMError::WasmerTrap(trap_code),
+            None => VMError::WasmerRuntimeError(e),
+        }
+    }
+}
+
+impl From<CanonError> for VMError {
+    fn from(e: CanonError) -> Self {
+        VMError::StoreError(e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,21 +11,21 @@
 #![allow(unreachable_code)]
 
 use std::collections::HashMap;
-use std::{fmt, io};
-
-use canonical::CanonError;
 
 mod call_context;
 mod compiler;
 mod compiler_config;
 mod contract;
 mod env;
+mod error;
 mod gas;
 mod memory;
 mod modules;
 mod ops;
 mod resolver;
 mod state;
+
+pub use error::VMError;
 
 pub use dusk_abi;
 
@@ -35,181 +35,6 @@ pub use state::NetworkState;
 
 #[cfg(feature = "persistence")]
 pub use state::persist::NetworkStateId;
-
-use thiserror::Error;
-use wasmer_vm::TrapCode;
-
-#[derive(Error)]
-/// The errors that can happen while executing the VM
-pub enum VMError {
-    /// Invalid arguments in host call
-    InvalidArguments,
-    /// The Stack is empty
-    EmptyStack,
-    /// The contract panicked with message in `String`
-    ContractPanic(String),
-    /// Could not find WASM memory
-    MemoryNotFound,
-    /// Error during the instrumentalization
-    InstrumentationError(modules::InstrumentationError),
-    /// Invalid ABI Call
-    InvalidABICall,
-    /// Invalid Utf8
-    InvalidUtf8,
-    /// Invalid Public key
-    InvalidEd25519PublicKey,
-    /// Invalid Signature
-    InvalidEd25519Signature,
-    /// Contract returned, not an error per se, this is how contracts return.
-    ContractReturn(i32, i32),
-    /// Contract execution ran out of gas
-    OutOfGas,
-    /// Not enough funds for call
-    NotEnoughFunds,
-    /// Contract could not be found in the state
-    UnknownContract,
-    /// WASM threw an error
-    WASMError(failure::Error),
-    /// Input output error
-    IOError(io::Error),
-    /// Invalid WASM Module
-    InvalidWASMModule,
-    /// Error propagated from underlying store
-    StoreError(CanonError),
-    /// Serialization error from the state persistence mechanism
-    PersistenceSerializationError(CanonError),
-    /// Other error from the state persistence mechanism
-    PersistenceError(String),
-    /// WASMER export error
-    WasmerExportError(wasmer::ExportError),
-    /// WASMER runtime error
-    WasmerRuntimeError(wasmer::RuntimeError),
-    /// WASMER compile error
-    WasmerCompileError(wasmer::CompileError),
-    /// WASMER trap
-    WasmerTrap(TrapCode),
-    /// WASMER instantiation error
-    WasmerInstantiationError(wasmer::InstantiationError),
-}
-
-impl From<io::Error> for VMError {
-    fn from(e: io::Error) -> Self {
-        VMError::IOError(e)
-    }
-}
-
-impl From<modules::InstrumentationError> for VMError {
-    fn from(e: modules::InstrumentationError) -> Self {
-        VMError::InstrumentationError(e)
-    }
-}
-
-impl From<gas::GasError> for VMError {
-    fn from(_: gas::GasError) -> Self {
-        // Currently the only gas error is `GasLimitExceeded`
-        VMError::OutOfGas
-    }
-}
-
-impl From<wasmer::InstantiationError> for VMError {
-    fn from(e: wasmer::InstantiationError) -> Self {
-        VMError::WasmerInstantiationError(e)
-    }
-}
-
-impl From<wasmer::ExportError> for VMError {
-    fn from(e: wasmer::ExportError) -> Self {
-        VMError::WasmerExportError(e)
-    }
-}
-
-impl From<wasmer::CompileError> for VMError {
-    fn from(e: wasmer::CompileError) -> Self {
-        VMError::WasmerCompileError(e)
-    }
-}
-
-impl From<wasmer::RuntimeError> for VMError {
-    fn from(e: wasmer::RuntimeError) -> Self {
-        let runtime_error = e.clone();
-        match e.to_trap() {
-            Some(trap_code) => VMError::WasmerTrap(trap_code),
-            _ => VMError::WasmerRuntimeError(runtime_error),
-        }
-    }
-}
-
-// The generic From<CanonError> is not specific enough and conflicts with
-// From<Self>.
-impl VMError {
-    /// Create a VMError from the associated stores
-    pub fn from_store_error(err: CanonError) -> Self {
-        VMError::StoreError(err)
-    }
-}
-
-impl fmt::Display for VMError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            VMError::InvalidArguments => write!(f, "Invalid arguments")?,
-            VMError::EmptyStack => write!(f, "The stack is empty")?,
-            VMError::ContractPanic(string) => {
-                write!(f, "Contract panic \"{}\"", string)?
-            }
-            VMError::InvalidUtf8 => write!(f, "Invalid UTF-8")?,
-            VMError::InvalidEd25519PublicKey => {
-                write!(f, "Invalid Ed25519 Public Key")?
-            }
-            VMError::InvalidEd25519Signature => {
-                write!(f, "Invalid Ed25519 Signature")?
-            }
-            VMError::ContractReturn(_, _) => write!(f, "Contract Return")?,
-            VMError::OutOfGas => write!(f, "Out of Gas error")?,
-            VMError::NotEnoughFunds => write!(f, "Not enough funds error")?,
-            VMError::WASMError(e) => write!(f, "WASM Error ({:?})", e)?,
-            VMError::MemoryNotFound => write!(f, "Memory not found")?,
-            VMError::InvalidABICall => write!(f, "Invalid ABI Call")?,
-            VMError::IOError(e) => write!(f, "Input/Output Error ({:?})", e)?,
-            VMError::UnknownContract => write!(f, "Unknown Contract")?,
-            VMError::InvalidWASMModule => write!(f, "Invalid WASM module")?,
-            VMError::StoreError(e) => write!(f, "Store error {:?}", e)?,
-            VMError::InstrumentationError(e) => {
-                write!(f, "Instrumentalization error {:?}", e)?
-            }
-            VMError::PersistenceSerializationError(e) => {
-                write!(f, "Persistence serialization error {:?}", e)?
-            }
-            VMError::PersistenceError(string) => {
-                write!(f, "Persistence error \"{}\"", string)?
-            }
-            VMError::WasmerExportError(e) => match e {
-                wasmer::ExportError::IncompatibleType => {
-                    write!(f, "WASMER Export Error - incompatible export type")?
-                }
-                wasmer::ExportError::Missing(s) => {
-                    write!(f, "WASMER Export Error - missing: \"{}\"", s)?
-                }
-            },
-            VMError::WasmerRuntimeError(e) => {
-                write!(f, "WASMER Runtime Error {:?}", e)?
-            }
-            VMError::WasmerTrap(e) => write!(f, "WASMER Trap ({:?})", e)?,
-            VMError::WasmerInstantiationError(e) => {
-                write!(f, "WASMER Instantiation Error ({:?})", e)?
-            }
-            VMError::WasmerCompileError(e) => {
-                write!(f, "WASMER Compile Error {:?}", e)?
-            }
-        }
-        Ok(())
-    }
-}
-
-impl fmt::Debug for VMError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
-    }
-}
 
 /// Definition of the cost schedule and other parameterizations for wasm vm.
 #[derive(Clone, PartialEq, Eq)]

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -83,6 +83,33 @@ pub enum InstrumentationError {
     InvalidInstructionType,
 }
 
+impl std::error::Error for InstrumentationError {}
+
+impl core::fmt::Display for InstrumentationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            InstrumentationError::GasMeteringInjection => {
+                write!(f, "Gas metering injection error")
+            }
+            InstrumentationError::StackHeightInjection => {
+                write!(f, "Stack height injection error")
+            }
+            InstrumentationError::MultipleTables => {
+                write!(f, "Multiple tables error")
+            }
+            InstrumentationError::MaxTableSize => {
+                write!(f, "Max table size error")
+            }
+            InstrumentationError::InvalidByteCode => {
+                write!(f, "Invalid bytecode")
+            }
+            InstrumentationError::InvalidInstructionType => {
+                write!(f, "Invalid instruction type")
+            }
+        }
+    }
+}
+
 #[derive(Clone, Hash, PartialEq, Eq)]
 pub struct ModuleConfig {
     pub version: u32,

--- a/src/ops/panic.rs
+++ b/src/ops/panic.rs
@@ -24,8 +24,9 @@ impl Panic {
         let slice = context.read_memory(panic_ofs, panic_len)?;
         Err(match String::from_utf8(slice.to_vec()) {
             Ok(panic_msg) => {
-                debug!("Contract panic: {:?}", panic_msg);
-                VMError::ContractPanic(panic_msg)
+                let contract_id = context.callee()?;
+                debug!("Contract {} panic: {:?}", contract_id, panic_msg);
+                VMError::ContractPanic(*contract_id, panic_msg)
             }
             Err(_) => {
                 debug!("Invalid UTF-8 in panic");

--- a/src/ops/query.rs
+++ b/src/ops/query.rs
@@ -31,8 +31,7 @@ impl ExecuteQuery {
         let contract_id = ContractId::from(&contract_id_memory);
         let query_memory = context.read_memory_from(query_ofs)?;
         let mut source = Source::new(query_memory);
-        let query =
-            Query::decode(&mut source).map_err(VMError::from_store_error)?;
+        let query = Query::decode(&mut source)?;
 
         let mut gas_meter = context.gas_meter()?.limited(gas_limit);
         let result = context.query(contract_id, query, &mut gas_meter)?;

--- a/src/ops/store.rs
+++ b/src/ops/store.rs
@@ -28,13 +28,12 @@ impl Get {
         let mem =
             context.read_memory(hash_ofs, core::mem::size_of::<IdHash>())?;
         let mut source = Source::new(mem);
-        let hash =
-            IdHash::decode(&mut source).map_err(VMError::from_store_error)?;
+        let hash = IdHash::decode(&mut source)?;
         // we don't allow get requests to fail in the bridge
         // communication since that is the
         // responsibility of the host.
         let mut dest = vec![0; write_len];
-        Store::get(&hash, &mut dest).map_err(VMError::from_store_error)?;
+        Store::get(&hash, &mut dest)?;
         context.write_memory(&dest, write_buf)?;
         Ok(())
     }

--- a/src/ops/transact.rs
+++ b/src/ops/transact.rs
@@ -33,10 +33,8 @@ impl ApplyTransaction {
         let transaction_memory =
             context.read_memory_from(transaction_offset)?;
         let mut source = Source::new(transaction_memory);
-        let state = ContractState::decode(&mut source)
-            .map_err(VMError::from_store_error)?;
-        let transaction = Transaction::decode(&mut source)
-            .map_err(VMError::from_store_error)?;
+        let state = ContractState::decode(&mut source)?;
+        let transaction = Transaction::decode(&mut source)?;
 
         let callee = *context.callee()?;
         *context.state_mut().get_contract_mut(&callee)?.state_mut() = state;

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -31,8 +31,7 @@ impl NetworkStateId {
     pub fn read<P: AsRef<Path>>(path: P) -> Result<Self, VMError> {
         let buf = fs::read(&path)?;
         let mut source = Source::new(&buf[..]);
-        let id = NetworkStateId::decode(&mut source)
-            .map_err(VMError::from_store_error)?;
+        let id = NetworkStateId::decode(&mut source)?;
 
         Ok(id)
     }

--- a/tests/contracts/callee-1/src/lib.rs
+++ b/tests/contracts/callee-1/src/lib.rs
@@ -57,15 +57,18 @@ mod hosted {
 
         match qid {
             CALL => {
+                let should_panic = bool::decode(&mut source)?;
                 let mut sink = Sink::new(&mut bytes[..]);
 
-                let ret =
-                    dusk_abi::query::<_, (ContractId, ContractId, ContractId)>(
-                        &slf.target_address,
-                        &(CALLEE_2_GET, sender, dusk_abi::callee()),
-                        0,
-                    )
-                    .expect("Query Succeeded");
+                let ret = dusk_abi::query::<
+                    _,
+                    (ContractId, ContractId, ContractId),
+                >(
+                    &slf.target_address,
+                    &(CALLEE_2_GET, sender, dusk_abi::callee(), should_panic),
+                    0,
+                )
+                .expect("Query Succeeded");
 
                 // return value
                 ReturnValue::from_canon(&ret).encode(&mut sink);

--- a/tests/contracts/callee-2/src/lib.rs
+++ b/tests/contracts/callee-2/src/lib.rs
@@ -47,8 +47,10 @@ mod hosted {
 
         assert_eq!(sender, dusk_abi::caller(), "Expected Caller");
 
+        let should_panic = bool::decode(&mut source)?;
+
         match qid {
-            GET => {
+            GET if !should_panic => {
                 let mut sink = Sink::new(&mut bytes[..]);
 
                 // return value
@@ -61,7 +63,7 @@ mod hosted {
 
                 Ok(())
             }
-            _ => panic!(""),
+            _ => panic!("Panic with flag set to: {}", should_panic),
         }
     }
 

--- a/tests/contracts/caller/src/lib.rs
+++ b/tests/contracts/caller/src/lib.rs
@@ -51,12 +51,13 @@ mod hosted {
         let qid = u8::decode(&mut source)?;
         match qid {
             CALL => {
-                let mut sink = Sink::new(&mut bytes[..]);
+                let should_panic = bool::decode(&mut source)?;
 
+                let mut sink = Sink::new(&mut bytes[..]);
                 let ret =
                     dusk_abi::query::<_, (ContractId, ContractId, ContractId)>(
                         &slf.target_address,
-                        &(CALLEE_1_CALL, dusk_abi::callee()),
+                        &(CALLEE_1_CALL, dusk_abi::callee(), should_panic),
                         0,
                     )
                     .expect("Query Succeeded");

--- a/tests/contracts/counter_float/Cargo.toml
+++ b/tests/contracts/counter_float/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib", "rlib"]
 canonical = "0.6"
 canonical_derive = "0.6"
 
-dusk-abi = "0.9.0-rc"
+dusk-abi = "0.10"


### PR DESCRIPTION
  - Change `VMError` to be in its own `error` module
  - Add `Debug` trait to `VMError`
  - Add `Display` and `std::error::Error` traits to `InstrumentationError`
  - Change syntax to `thiserror` to simplify conversion and display messages
  - Remove `VMError::from_store_error`
  - Remove unused errors.
  
    Here the list of the errors removed:
    InvalidArguments, MemoryNotFound, InvalidABICall,
    InvalidEd25519PublicKey, InvalidEd25519Signature, ContractReturn,
    NotEnoughFunds, WASMError, InvalidWASMModule,
    PersistenceSerializationError, PersistenceError,
  
  - Change how the conversion from `wasmer::RuntimeError` to `VMError` is
    done.
  
    Now we `downcast` to `VMError` if `wasmer::RuntimeError` is a wrapper
    to a `VMError`.

  - Add test for `UnknownContract` error
  - Add test for `ContractPanic` error
  - Update `gas_consumed_host_function_works` test

  - Bump to `v0.12.0-rc.0`

See also: dusk-network/rusk#599
Resolves #301


