### PR TITLE
Update to `microkelvin` 0.15 and `canonical` 0.7

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -1,11 +1,11 @@
-on: [ pull_request ]
+on: [pull_request]
 
 name: Continuous integration
 
 jobs:
   analyze:
     name: Dusk Analyzer
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -52,8 +52,8 @@ jobs:
       - name: Build test executables
         uses: actions-rs/cargo@v1
         env:
-          RUSTFLAGS: '-Cinline-threshold=0 -Clink-dead-code'
-          RUSTDOCFLAGS: '-Cinline-threshold=0 -Clink-dead-code'
+          RUSTFLAGS: "-Cinline-threshold=0 -Clink-dead-code"
+          RUSTDOCFLAGS: "-Cinline-threshold=0 -Clink-dead-code"
         with:
           command: test
           args: --all-features --no-run
@@ -75,7 +75,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: core
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ license = "MPL-2.0"
 [dependencies]
 wasmparser = "0.81"
 failure = "0.1"
-dusk-abi = "0.10"
-canonical = "0.6"
-canonical_derive = "0.6"
-dusk-hamt = "0.9"
-microkelvin = { version = "0.14", features = ["persistence"] }
+dusk-abi = "0.11"
+canonical = "0.7"
+canonical_derive = "0.7"
+dusk-hamt = "0.10.0-rc"
+microkelvin = { version = "0.15.0-rc", features = ["persistence"] }
 wasmer = "2.1"
 wasmer-vm = "2.1"
 wasmer-engine-universal = "2.1"
@@ -72,7 +72,3 @@ members = [
     "tests/contracts/*",
 ]
 exclude = ["test_runner"]
-
-[patch.crates-io]
-microkelvin = { path = "../microkelvin" }
-canonical = { path = "../canonical/canon" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ dusk-abi = "0.10"
 canonical = "0.6"
 canonical_derive = "0.6"
 dusk-hamt = "0.9"
-microkelvin = "0.14"
+microkelvin = { version = "0.14", features = ["persistence"] }
 wasmer = "2.1"
 wasmer-vm = "2.1"
 wasmer-engine-universal = "2.1"
@@ -73,5 +73,6 @@ members = [
 ]
 exclude = ["test_runner"]
 
-[features]
-persistence = ["dusk-hamt/persistence", "microkelvin/persistence"]
+[patch.crates-io]
+microkelvin = { path = "../microkelvin" }
+canonical = { path = "../canonical/canon" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ wasmer-compiler-singlepass = "2.1"
 wasmer-compiler-cranelift = "2.1"
 
 [dev-dependencies]
-dusk-bls12_381 = "0.8"
+dusk-bls12_381 = "0.9"
 dusk-bytes = "0.1"
 criterion = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,5 +70,6 @@ harness = false
 [workspace]
 members = [
     "tests/contracts/*",
+    "test_runner"
 ]
 exclude = ["test_runner"]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 
 use canonical::{Canon, CanonError};
 use canonical_derive::Canon;
-use microkelvin::{Child, ChildMut, Compound, GenericTree, Link, LinkCompound};
+use microkelvin::{Child, ChildMut, Compound, Link, LinkCompound};
 
 pub use dusk_abi::{ContractId, ContractState};
 
@@ -50,10 +50,6 @@ impl Compound<()> for ContractCode {
         } else {
             ChildMut::EndOfNode
         }
-    }
-
-    fn from_generic(_tree: &GenericTree) -> Result<Self, CanonError> {
-        todo!("deprecated");
     }
 }
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -8,9 +8,7 @@ use std::ops::Deref;
 
 use canonical::{Canon, CanonError};
 use canonical_derive::Canon;
-use microkelvin::{
-    Child, ChildMut, Compound, GenericChild, GenericTree, Link, LinkCompound,
-};
+use microkelvin::{Child, ChildMut, Compound, GenericTree, Link, LinkCompound};
 
 pub use dusk_abi::{ContractId, ContractState};
 
@@ -54,11 +52,8 @@ impl Compound<()> for ContractCode {
         }
     }
 
-    fn from_generic(tree: &GenericTree) -> Result<Self, CanonError> {
-        match tree.children().first() {
-            Some(GenericChild::Leaf(leaf)) => Ok(ContractCode(leaf.cast()?)),
-            _ => Err(CanonError::InvalidEncoding),
-        }
+    fn from_generic(_tree: &GenericTree) -> Result<Self, CanonError> {
+        todo!("deprecated");
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ use crate::modules;
 
 use canonical::CanonError;
 use dusk_abi::ContractId;
+use microkelvin::PersistError;
 use std::io;
 use thiserror::Error;
 use wasmer_vm::TrapCode;
@@ -40,9 +41,9 @@ pub enum VMError {
     /// Error propagated from underlying store
     #[error("Error propagated from underlying store")]
     StoreError(CanonError),
-    /// Error during persistence
-    #[error("Persistence Error: {0}")]
-    PersistenceError(String),
+    /// Persistence error
+    #[error(transparent)]
+    PersistenceError(#[from] PersistError),
     /// WASMER export error
     #[error(transparent)]
     WasmerExportError(#[from] wasmer::ExportError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,9 @@ pub enum VMError {
     /// Error propagated from underlying store
     #[error("Error propagated from underlying store")]
     StoreError(CanonError),
+    /// Error during persistence
+    #[error("Persistence Error: {0}")]
+    PersistenceError(String),
     /// WASMER export error
     #[error(transparent)]
     WasmerExportError(#[from] wasmer::ExportError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ pub use contract::{Contract, ContractId};
 pub use gas::{Gas, GasMeter};
 pub use state::NetworkState;
 
-#[cfg(feature = "persistence")]
 pub use state::persist::NetworkStateId;
 
 /// Definition of the cost schedule and other parameterizations for wasm vm.

--- a/src/ops/store.rs
+++ b/src/ops/store.rs
@@ -30,17 +30,7 @@ impl Get {
         let mem =
             context.read_memory(hash_ofs, core::mem::size_of::<IdHash>())?;
         let mut source = Source::new(mem);
-<<<<<<< HEAD
         let hash = IdHash::decode(&mut source)?;
-        // we don't allow get requests to fail in the bridge
-        // communication since that is the
-        // responsibility of the host.
-        let mut dest = vec![0; write_len];
-        Store::get(&hash, &mut dest)?;
-        context.write_memory(&dest, write_buf)?;
-=======
-        let hash =
-            IdHash::decode(&mut source).map_err(VMError::from_store_error)?;
         let id = canonical::Id::raw(hash, write_len as u32);
 
         // we don't allow get requests to fail in the bridge
@@ -52,7 +42,6 @@ impl Get {
 
         context.write_memory(&bytes, write_buf)?;
 
->>>>>>> c3aaad5 (Change store ops to always use microkelvin)
         Ok(())
     }
 }

--- a/src/ops/store.rs
+++ b/src/ops/store.rs
@@ -37,8 +37,7 @@ impl Get {
         // communication since that is the
         // responsibility of the host.
 
-        let bytes = Persistence::get_raw(&id)
-            .map_err(|e| VMError::PersistenceError(format!("{:?}", e)))?;
+        let bytes = Persistence::get_raw(&id)?;
 
         context.write_memory(&bytes, write_buf)?;
 
@@ -59,8 +58,7 @@ impl Put {
 
         let mem = context.read_memory(ofs, len)?;
 
-        let id = microkelvin::Persistence::put(mem)
-            .map_err(|e| VMError::PersistenceError(format!("{:?}", e)))?;
+        let id = microkelvin::Persistence::put(mem)?;
 
         let hash = id.hash();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,7 +19,6 @@ use crate::modules::ModuleConfig;
 use crate::modules::{compile_module, HostModules};
 use crate::{Schedule, VMError};
 
-#[cfg(feature = "persistence")]
 pub mod persist;
 
 /// State of the contracts on the network.

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -6,9 +6,8 @@
 
 use canonical::{Canon, Sink, Source};
 use canonical_derive::Canon;
-use dusk_hamt::Map;
 use microkelvin::{
-    Backend, BackendCtor, Compound, PersistError, PersistedId, Persistence,
+    Backend, BackendCtor, PersistError, PersistedId, Persistence,
 };
 use std::fs;
 use std::path::Path;
@@ -70,10 +69,10 @@ impl NetworkState {
     /// Given a [`NetworkStateId`] restores both [`Hamt`] which stores the
     /// contracts of the entire blockchain state.
     pub fn restore(mut self, id: NetworkStateId) -> Result<Self, PersistError> {
-        let map = Map::from_generic(&id.origin.restore()?)?;
+        let map = id.origin.restore()?;
         self.origin = Contracts(map);
 
-        let map = Map::from_generic(&id.head.restore()?)?;
+        let map = id.head.restore()?;
         self.head = Contracts(map);
 
         self.staged = self.head.clone();

--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 rusk-vm = { path = ".." }
 counter = { path = "../tests/contracts/counter" }
 map = { path = "../tests/contracts/map" }
-microkelvin = { version = "0.14", features = ["persistence"] }
+microkelvin = { version = "0.15.0-rc", features = ["persistence"] }
 
-[patch.crates-io]
-microkelvin = { path = "../../microkelvin" }
-canonical = { path = "../../canonical/canon" }
+

--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 rusk-vm = { path = "..", features = ["persistence"] }
 counter = { path = "../tests/contracts/counter" }
+map = { path = "../tests/contracts/map" }
 microkelvin = { version = "0.14", features = ["persistence"] }

--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rusk-vm = { path = "..", features = ["persistence"] }
+rusk-vm = { path = ".." }
 counter = { path = "../tests/contracts/counter" }
 map = { path = "../tests/contracts/map" }
 microkelvin = { version = "0.14", features = ["persistence"] }
+
+[patch.crates-io]
+microkelvin = { path = "../../microkelvin" }
+canonical = { path = "../../canonical/canon" }

--- a/test_runner/src/main.rs
+++ b/test_runner/src/main.rs
@@ -37,7 +37,7 @@ impl Display for PersistE {
     }
 }
 
-const MAP_SIZE: u8 = 6;
+const MAP_SIZE: u8 = 64;
 
 fn initialize_counter(
     backend: &BackendCtor<DiskBackend>,
@@ -82,7 +82,8 @@ fn initialize_counter(
 
     persist_id.write(file_path)?;
 
-    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("counter_contract_id");
+    let contract_id_path =
+        PathBuf::from(unsafe { &PATH }).join("counter_contract_id");
 
     fs::write(&contract_id_path, contract_id.as_bytes())?;
 
@@ -94,9 +95,8 @@ fn initialize_map(
 ) -> Result<(), Box<dyn Error>> {
     let counter = Map::new();
 
-    let code = include_bytes!(
-        "../../target/wasm32-unknown-unknown/release/map.wasm"
-    );
+    let code =
+        include_bytes!("../../target/wasm32-unknown-unknown/release/map.wasm");
 
     let contract = Contract::new(counter, code.to_vec());
 
@@ -125,7 +125,8 @@ fn initialize_map(
 
     persist_id.write(file_path)?;
 
-    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("map_contract_id");
+    let contract_id_path =
+        PathBuf::from(unsafe { &PATH }).join("map_contract_id");
 
     fs::write(&contract_id_path, contract_id.as_bytes())?;
 
@@ -140,7 +141,9 @@ fn initialize(
     Ok(())
 }
 
-fn confirm_counter(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>> {
+fn confirm_counter(
+    _backend: &BackendCtor<DiskBackend>,
+) -> Result<(), Box<dyn Error>> {
     let file_path = PathBuf::from(unsafe { &PATH }).join("counter_persist_id");
     let state_id = NetworkStateId::read(file_path)?;
 
@@ -148,7 +151,8 @@ fn confirm_counter(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Er
         .restore(state_id)
         .map_err(|_| PersistE)?;
 
-    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("counter_contract_id");
+    let contract_id_path =
+        PathBuf::from(unsafe { &PATH }).join("counter_contract_id");
     let buf = fs::read(&contract_id_path)?;
 
     let contract_id = ContractId::from(buf);
@@ -165,7 +169,9 @@ fn confirm_counter(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Er
     Ok(())
 }
 
-fn confirm_map(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>> {
+fn confirm_map(
+    _backend: &BackendCtor<DiskBackend>,
+) -> Result<(), Box<dyn Error>> {
     let file_path = PathBuf::from(unsafe { &PATH }).join("map_persist_id");
     let state_id = NetworkStateId::read(file_path)?;
 
@@ -173,7 +179,8 @@ fn confirm_map(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>
         .restore(state_id)
         .map_err(|_| PersistE)?;
 
-    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("map_contract_id");
+    let contract_id_path =
+        PathBuf::from(unsafe { &PATH }).join("map_contract_id");
     let buf = fs::read(&contract_id_path)?;
 
     let contract_id = ContractId::from(buf);

--- a/test_runner/src/main.rs
+++ b/test_runner/src/main.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use counter::*;
+use map::*;
 use microkelvin::*;
 use rusk_vm::*;
 
@@ -36,7 +37,9 @@ impl Display for PersistE {
     }
 }
 
-fn initialize(
+const MAP_SIZE: u8 = 6;
+
+fn initialize_counter(
     backend: &BackendCtor<DiskBackend>,
 ) -> Result<(), Box<dyn Error>> {
     let counter = Counter::new(99);
@@ -75,26 +78,77 @@ fn initialize(
 
     let persist_id = network.persist(backend).expect("Error in persistence");
 
-    let file_path = PathBuf::from(unsafe { &PATH }).join("persist_id");
+    let file_path = PathBuf::from(unsafe { &PATH }).join("counter_persist_id");
 
     persist_id.write(file_path)?;
 
-    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("contract_id");
+    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("counter_contract_id");
 
     fs::write(&contract_id_path, contract_id.as_bytes())?;
 
     Ok(())
 }
 
-fn confirm(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>> {
-    let file_path = PathBuf::from(unsafe { &PATH }).join("persist_id");
+fn initialize_map(
+    backend: &BackendCtor<DiskBackend>,
+) -> Result<(), Box<dyn Error>> {
+    let counter = Map::new();
+
+    let code = include_bytes!(
+        "../../target/wasm32-unknown-unknown/release/map.wasm"
+    );
+
+    let contract = Contract::new(counter, code.to_vec());
+
+    let mut network = NetworkState::new();
+
+    let contract_id = network.deploy(contract).unwrap();
+
+    let mut gas = GasMeter::with_limit(1_000_000_000);
+
+    for i in 0..MAP_SIZE {
+        network
+            .transact::<_, Option<u32>>(
+                contract_id,
+                0,
+                (map::SET, i, i as u32),
+                &mut gas,
+            )
+            .unwrap();
+    }
+
+    network.commit();
+
+    let persist_id = network.persist(backend).expect("Error in persistence");
+
+    let file_path = PathBuf::from(unsafe { &PATH }).join("map_persist_id");
+
+    persist_id.write(file_path)?;
+
+    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("map_contract_id");
+
+    fs::write(&contract_id_path, contract_id.as_bytes())?;
+
+    Ok(())
+}
+
+fn initialize(
+    backend: &BackendCtor<DiskBackend>,
+) -> Result<(), Box<dyn Error>> {
+    initialize_counter(backend)?;
+    initialize_map(backend)?;
+    Ok(())
+}
+
+fn confirm_counter(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>> {
+    let file_path = PathBuf::from(unsafe { &PATH }).join("counter_persist_id");
     let state_id = NetworkStateId::read(file_path)?;
 
     let mut network = NetworkState::new()
         .restore(state_id)
         .map_err(|_| PersistE)?;
 
-    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("contract_id");
+    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("counter_contract_id");
     let buf = fs::read(&contract_id_path)?;
 
     let contract_id = ContractId::from(buf);
@@ -108,6 +162,44 @@ fn confirm(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>> {
         100
     );
 
+    Ok(())
+}
+
+fn confirm_map(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>> {
+    let file_path = PathBuf::from(unsafe { &PATH }).join("map_persist_id");
+    let state_id = NetworkStateId::read(file_path)?;
+
+    let mut network = NetworkState::new()
+        .restore(state_id)
+        .map_err(|_| PersistE)?;
+
+    let contract_id_path = PathBuf::from(unsafe { &PATH }).join("map_contract_id");
+    let buf = fs::read(&contract_id_path)?;
+
+    let contract_id = ContractId::from(buf);
+
+    let mut gas = GasMeter::with_limit(1_000_000_000);
+
+    for i in 0..MAP_SIZE {
+        assert_eq!(
+            network
+                .query::<_, Option<u32>>(
+                    contract_id,
+                    0,
+                    (map::GET, i),
+                    &mut gas
+                )
+                .unwrap(),
+            Some(i as u32)
+        );
+    }
+
+    Ok(())
+}
+
+fn confirm(_backend: &BackendCtor<DiskBackend>) -> Result<(), Box<dyn Error>> {
+    confirm_counter(_backend)?;
+    confirm_map(_backend)?;
     Ok(())
 }
 

--- a/tests/contracts/block_height/Cargo.toml
+++ b/tests/contracts/block_height/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
-dusk-abi = "0.10"
+canonical = "0.7"
+canonical_derive = "0.7"
+dusk-abi = "0.11"

--- a/tests/contracts/callee-1/Cargo.toml
+++ b/tests/contracts/callee-1/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/callee-2/Cargo.toml
+++ b/tests/contracts/callee-2/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/caller/Cargo.toml
+++ b/tests/contracts/caller/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/counter/Cargo.toml
+++ b/tests/contracts/counter/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"
 

--- a/tests/contracts/counter_float/Cargo.toml
+++ b/tests/contracts/counter_float/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/delegator/Cargo.toml
+++ b/tests/contracts/delegator/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"
 

--- a/tests/contracts/fibonacci/Cargo.toml
+++ b/tests/contracts/fibonacci/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/gas_consumed/Cargo.toml
+++ b/tests/contracts/gas_consumed/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/gas_context/Cargo.toml
+++ b/tests/contracts/gas_context/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/host_fn/Cargo.toml
+++ b/tests/contracts/host_fn/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/map/Cargo.toml
+++ b/tests/contracts/map/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-hamt = "0.9"
-dusk-abi = "0.10"
+dusk-hamt = "0.10.0-rc"
+dusk-abi = "0.11"

--- a/tests/contracts/map/src/lib.rs
+++ b/tests/contracts/map/src/lib.rs
@@ -34,7 +34,7 @@ impl Map {
     }
 
     pub fn get(&self, key: &u8) -> Option<u32> {
-        self.inner.get(key).map(|x| x.map(|x| *x)).ok()?
+        self.inner.get(key).ok()?.map(|x|*x)
     }
 
     pub fn remove(&mut self, key: &u8) -> Result<Option<u32>, CanonError> {

--- a/tests/contracts/map/src/lib.rs
+++ b/tests/contracts/map/src/lib.rs
@@ -34,7 +34,7 @@ impl Map {
     }
 
     pub fn get(&self, key: &u8) -> Option<u32> {
-        self.inner.get(key).ok()?.map(|x|*x)
+        self.inner.get(key).ok()?.map(|x| *x)
     }
 
     pub fn remove(&mut self, key: &u8) -> Result<Option<u32>, CanonError> {

--- a/tests/contracts/self_snapshot/Cargo.toml
+++ b/tests/contracts/self_snapshot/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/stack/Cargo.toml
+++ b/tests/contracts/stack/Cargo.toml
@@ -8,12 +8,9 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-nstack = "0.13.0"
-microkelvin = "0.14"
-dusk-abi = "0.10"
-
-[patch.crates-io]
-microkelvin = { path = "../../../microkelvin" }
+nstack = "0.14.0-rc"
+microkelvin = "0.15.0-rc"
+dusk-abi = "0.11"

--- a/tests/contracts/stack/Cargo.toml
+++ b/tests/contracts/stack/Cargo.toml
@@ -14,3 +14,6 @@ canonical_derive = "0.6"
 nstack = "0.13.0"
 microkelvin = "0.14"
 dusk-abi = "0.10"
+
+[patch.crates-io]
+microkelvin = { path = "../../../microkelvin" }

--- a/tests/contracts/tx_vec/Cargo.toml
+++ b/tests/contracts/tx_vec/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+canonical = "0.7"
+canonical_derive = "0.7"
 
-dusk-abi = "0.10"
+dusk-abi = "0.11"

--- a/tests/contracts/tx_vec/src/lib.rs
+++ b/tests/contracts/tx_vec/src/lib.rs
@@ -103,7 +103,7 @@ mod hosted {
 
                 let mut sink = Sink::new(&mut bytes[..]);
                 // return new state
-                &ContractState::from_canon(&slf).encode(&mut sink);
+                ContractState::from_canon(&slf).encode(&mut sink);
 
                 // return value
                 ReturnValue::from_canon(&()).encode(&mut sink);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -781,7 +781,12 @@ fn map() {
 
         assert_eq!(
             network
-                .query::<_, Option<u32>>(contract_id, 0, (map::GET, i), &mut gas)
+                .query::<_, Option<u32>>(
+                    contract_id,
+                    0,
+                    (map::GET, i),
+                    &mut gas
+                )
                 .unwrap(),
             Some(i as u32)
         );
@@ -799,7 +804,12 @@ fn map() {
     for i in 1..N {
         assert_eq!(
             network
-                .query::<_, Option<u32>>(contract_id, 0, (map::GET, i), &mut gas)
+                .query::<_, Option<u32>>(
+                    contract_id,
+                    0,
+                    (map::GET, i),
+                    &mut gas
+                )
                 .unwrap(),
             None
         );

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -767,19 +767,41 @@ fn map() {
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
 
-    network
-        .transact::<_, Option<u32>>(
-            contract_id,
-            0,
-            (map::SET, 1, 13u32),
-            &mut gas,
-        )
-        .unwrap();
+    const N: u8 = 16;
 
-    assert_eq!(
+    for i in 1..N {
         network
-            .query::<_, Option<u32>>(contract_id, 0, (map::GET, 1), &mut gas)
-            .unwrap(),
-        Some(13)
-    );
+            .transact::<_, Option<u32>>(
+                contract_id,
+                0,
+                (map::SET, i, i as u32),
+                &mut gas,
+            )
+            .unwrap();
+
+        assert_eq!(
+            network
+                .query::<_, Option<u32>>(contract_id, 0, (map::GET, i), &mut gas)
+                .unwrap(),
+            Some(i as u32)
+        );
+
+        network
+            .transact::<_, Option<u32>>(
+                contract_id,
+                0,
+                (map::REMOVE, i, i as u32),
+                &mut gas,
+            )
+            .unwrap();
+    }
+
+    for i in 1..N {
+        assert_eq!(
+            network
+                .query::<_, Option<u32>>(contract_id, 0, (map::GET, i), &mut gas)
+                .unwrap(),
+            None
+        );
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -21,6 +21,11 @@ use rusk_vm::{
 use self_snapshot::SelfSnapshot;
 use tx_vec::TxVec;
 
+use microkelvin::{BackendCtor, DiskBackend, Persistence};
+fn testbackend() -> BackendCtor<DiskBackend> {
+    BackendCtor::new(DiskBackend::ephemeral)
+}
+
 fn fibonacci_reference(n: u64) -> u64 {
     if n < 2 {
         n
@@ -686,11 +691,6 @@ fn deploy_with_id() -> Result<(), VMError> {
 
 #[test]
 fn persistence() {
-    use microkelvin::{BackendCtor, DiskBackend};
-    fn testbackend() -> BackendCtor<DiskBackend> {
-        BackendCtor::new(DiskBackend::ephemeral)
-    }
-
     let counter = Counter::new(99);
 
     let code =
@@ -753,6 +753,9 @@ fn persistence() {
 
 #[test]
 fn map() {
+    Persistence::with_backend(&testbackend(), |_| Ok(()))
+        .expect("Backend should be registered");
+
     let map = Map::new();
 
     let code =

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -684,7 +684,6 @@ fn deploy_with_id() -> Result<(), VMError> {
     Ok(())
 }
 
-#[cfg(feature = "persistence")]
 #[test]
 fn persistence() {
     use microkelvin::{BackendCtor, DiskBackend};

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -5,13 +5,20 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use canonical::CanonError;
+use microkelvin::{BackendCtor, DiskBackend, Persistence};
 
 use rusk_vm::{Contract, GasMeter, NetworkState};
 
 use stack::Stack;
 
+fn testbackend() -> BackendCtor<DiskBackend> {
+    BackendCtor::new(DiskBackend::ephemeral)
+}
+
 #[test]
 fn stack() {
+    Persistence::with_backend(&testbackend(), |_| Ok(())).unwrap();
+
     type Leaf = u64;
     const N: Leaf = 64;
 
@@ -81,13 +88,9 @@ fn stack() {
     );
 }
 
-#[cfg(feature = "persistence")]
 #[test]
 fn stack_persist() {
-    use microkelvin::{BackendCtor, DiskBackend};
-    fn testbackend() -> BackendCtor<DiskBackend> {
-        BackendCtor::new(DiskBackend::ephemeral)
-    }
+    Persistence::with_backend(&testbackend(), |_| Ok(())).unwrap();
 
     type Leaf = u64;
     const N: Leaf = 64;


### PR DESCRIPTION
- Improved map contract and test
- Add session test for dusk-hamt map
- Change store ops to always use microkelvin
- Bump versions across canonical, microkelvin and dusk-abi
- Add proper `PersistError` to `VMError`

Resolves #312