### PR TITLE
Remove state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change `NetworkState::transact` to return both a receipt and the resulting state [#357]
+- Change `NetworkState::transact` and `NetworkState::query` to take immutable
+  receivers [#357]
 - Change host functions to charge their cost according to config [#205]
 - Change `Config` to include `host_costs` [#205]
 - Change persistence to include configuration hash [#304]
@@ -37,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove state management from `NetworkState` [#357]
 - Remove `NetworkState::with_schedule` [#304]
 - Remove `ModuleConfig` and `NetworkState::get_module_config` [#304]
 - Remove `Schedule` as configuration structure [#304]
@@ -254,6 +258,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial
 
 [#374]: https://github.com/dusk-network/rusk-vm/issues/374
+[#357]: https://github.com/dusk-network/rusk-vm/issues/357
 [#333]: https://github.com/dusk-network/rusk-vm/issues/333
 [#308]: https://github.com/dusk-network/rusk-vm/issues/308
 [#304]: https://github.com/dusk-network/rusk-vm/issues/304

--- a/benches/stack.rs
+++ b/benches/stack.rs
@@ -22,7 +22,10 @@ fn stack_64(
     const N: Leaf = 64;
 
     for i in 0..N {
-        let _ = network.transact(contract_id, 0, stack::Push::new(i), gas);
+        let (_, new_network) = network
+            .transact(contract_id, 0, stack::Push::new(i), gas)
+            .expect("push to stack should succeed");
+        *network = new_network;
     }
 }
 

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -121,7 +121,7 @@ fn execute_contract_with_config(config: &'static Config) -> u64 {
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
 
-    network
+    let (_, network) = network
         .transact(contract_id, 0, counter::Increment, &mut gas)
         .expect("Transaction error");
 

--- a/tests/contracts/delegator/src/lib.rs
+++ b/tests/contracts/delegator/src/lib.rs
@@ -81,7 +81,7 @@ impl Transaction for TransactionForwardData {
 
 #[execute(name = "delegate_query")]
 impl Execute<QueryForwardData> for Delegator {
-    fn execute(&self, arg: QueryForwardData, store: StoreContext) -> u32 {
+    fn execute(&self, arg: QueryForwardData, mut store: StoreContext) -> u32 {
         let query_name = arg.name.as_ref();
         let mut query_data = AlignedVec::new();
         query_data.extend_from_slice(arg.data.as_ref());
@@ -91,7 +91,7 @@ impl Execute<QueryForwardData> for Delegator {
         );
         let res = result.cast_data::<<QueryForwardData as Query>::Return>();
         let res: <QueryForwardData as Query>::Return =
-            res.deserialize(&mut store.clone()).unwrap();
+            res.deserialize(&mut store).unwrap();
         res
     }
 }

--- a/tests/contracts/register/src/lib.rs
+++ b/tests/contracts/register/src/lib.rs
@@ -68,7 +68,7 @@ impl Execute<NumSecrets> for Register {
             .as_ref()
             .map(|branch| match branch.leaf() {
                 MaybeArchived::Memory(m) => *m,
-                MaybeArchived::Archived(a) => (*a).into(),
+                MaybeArchived::Archived(a) => *a,
             })
             .unwrap_or(0)
     }
@@ -88,7 +88,7 @@ impl Apply<Gossip> for Register {
         if let Some(mut branch) = self.open_secrets.get_mut(&t.0) {
             *branch.leaf_mut() += 1;
         } else {
-            self.open_secrets.insert(t.0.clone(), 1);
+            self.open_secrets.insert(t.0, 1);
         }
     }
 }

--- a/tests/contracts/tx_vec/src/lib.rs
+++ b/tests/contracts/tx_vec/src/lib.rs
@@ -31,7 +31,7 @@ impl TxVec {
 
     pub fn sum(&mut self, values: impl AsRef<[u8]>) {
         let values: &[u8] = &Box::from(values.as_ref());
-        self.value += values.into_iter().fold(0u8, |s, v| s.wrapping_add(*v));
+        self.value += values.iter().fold(0u8, |s, v| s.wrapping_add(*v));
     }
 
     pub fn delegate_sum(

--- a/tests/dual_test.rs
+++ b/tests/dual_test.rs
@@ -72,10 +72,11 @@ where
 
         let a = self.state.apply(t.clone(), self.store.clone());
 
-        let b = self
+        let (b, network) = self
             .network
             .transact(self.contract_id, 0, t, &mut gas)
             .unwrap();
+        self.network = network;
 
         assert_eq!(a, *b, "Direct call and wasm transaction differ in result");
         a

--- a/tests/gas_context.rs
+++ b/tests/gas_context.rs
@@ -38,13 +38,13 @@ fn gas_context() {
 
     let call_gas_limits = vec![0; NUMBER_OF_NESTED_CALLS];
 
-    network
+    let (_, network) = network
         .transact(contract_id, 0, SetGasLimits::new(call_gas_limits), &mut gas)
         .unwrap();
 
     let mut gas = GasMeter::with_limit(INITIAL_GAS_LIMIT);
 
-    network
+    let (_, network) = network
         .transact(
             contract_id,
             0,
@@ -102,7 +102,7 @@ fn gas_context_with_call_limit() {
 
     let number_of_nested_calls: usize = call_gas_limits.len();
 
-    network
+    let (_, network) = network
         .transact(
             contract_id,
             0,
@@ -111,7 +111,7 @@ fn gas_context_with_call_limit() {
         )
         .unwrap();
 
-    network
+    let (_, network) = network
         .transact(
             contract_id,
             0,

--- a/tests/gas_usage.rs
+++ b/tests/gas_usage.rs
@@ -25,7 +25,7 @@ fn execute_counter_contract() -> u64 {
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
 
-    network
+    let (_, network) = network
         .transact(contract_id, 0, counter::Increment, &mut gas)
         .expect("Transaction error");
 
@@ -49,7 +49,7 @@ fn execute_stack_single_push_pop_contract() -> u64 {
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
 
-    network
+    let (_, network) = network
         .transact(contract_id, 0, stack::Push::new(100), &mut gas)
         .expect("Transaction error");
 
@@ -73,13 +73,13 @@ fn execute_stack_multi_push_pop_contract(count: u64) -> u64 {
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
 
-    network
+    let (_, network) = network
         .transact(contract_id, 0, stack::PushMulti::new(count), &mut gas)
         .expect("Transaction error");
 
     network
         .transact(contract_id, 0, stack::PopMulti::new(count), &mut gas)
-        .expect("Query error");
+        .expect("Transaction error");
 
     gas.spent()
 }
@@ -98,9 +98,10 @@ fn execute_multiple_transactions_stack_contract(count: u64) -> u64 {
     let mut gas = GasMeter::with_limit(1_000_000_000);
 
     for i in 0..count {
-        network
+        let (_, new_network) = network
             .transact(contract_id, 0, Push::new(i), &mut gas)
             .unwrap();
+        network = new_network;
     }
 
     gas.spent()
@@ -132,9 +133,10 @@ fn execute_multiple_register_contract(count: u64) -> u64 {
     let secret_hash = SecretHash::new(secret_data);
 
     for _ in 0..count {
-        network
+        let (_, new_network) = network
             .transact(contract_id, 0, Gossip::new(secret_hash), &mut gas)
             .expect("Transaction error");
+        network = new_network;
 
         network
             .query(contract_id, 0, NumSecrets::new(secret_hash), &mut gas)


### PR DESCRIPTION
State management was previously done as a quick way to be able to manage
multiple states at the same time. This change makes the user responsible
for when they *keep* the state resulting from a transaction, as opposed
to when they *discard* said state.

Resolves #357