### PR TITLE
Change `NetworkState` construction and persistance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Add `NetworkState::store` [#319]
+- Add `NetworkState::builder` [#319]
+- Add `Default` implementation for `NetworkState` [#319]
+- Add `NetworkStateBuilder` [#319]
 - Introduce lang items as in `dusk-abi` [#374]
 - Add `HostCosts` config structure [#205]
 - Add `NetworkState::with_config` for instantiating a VM with the given configuration [#304]
@@ -25,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change `NetworkState::persist` to require no arguments [#319]
+- Change `NetworkState::new` to require no arguments [#319]
 - Change `NetworkState::transact` to return both a receipt and the resulting state [#357]
 - Change `NetworkState::transact` and `NetworkState::query` to take immutable
   receivers [#357]
@@ -40,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove `NetworkState::restore_from_disk` and `NetworkState::restore` [#319]
+- Remove `NetworkState::persist_to_disk` [#319]
+- Remove `NetworkState::with_config` [#319]
+- Remove `NetworkStateId` [#319]
 - Remove state management from `NetworkState` [#357]
 - Remove `NetworkState::with_schedule` [#304]
 - Remove `ModuleConfig` and `NetworkState::get_module_config` [#304]
@@ -260,6 +270,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#374]: https://github.com/dusk-network/rusk-vm/issues/374
 [#357]: https://github.com/dusk-network/rusk-vm/issues/357
 [#333]: https://github.com/dusk-network/rusk-vm/issues/333
+[#319]: https://github.com/dusk-network/rusk-vm/issues/319
 [#308]: https://github.com/dusk-network/rusk-vm/issues/308
 [#304]: https://github.com/dusk-network/rusk-vm/issues/304
 [#302]: https://github.com/dusk-network/rusk-vm/issues/302

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -6,7 +6,6 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use fibonacci::Fibonacci;
-use microkelvin::{HostStore, StoreRef};
 use rusk_vm::{Contract, ContractId, GasMeter, NetworkState};
 
 fn get_config() -> Criterion {
@@ -32,12 +31,11 @@ fn fibonacci_bench(c: &mut Criterion) {
         ".wasm"
     ));
 
-    let store = StoreRef::new(HostStore::new());
-    let contract = Contract::new(&Fibonacci, code.to_vec(), &store);
+    let mut network = NetworkState::new();
 
-    let mut network = NetworkState::new(store);
-
+    let contract = Contract::new(&Fibonacci, code.to_vec(), network.store());
     let contract_id = network.deploy(contract).unwrap();
+
     let mut gas = GasMeter::with_limit(1_000_000_000_000);
     c.bench_function("fibonacci 15", |b| {
         b.iter(|| {

--- a/benches/stack.rs
+++ b/benches/stack.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use microkelvin::{HostStore, StoreRef};
 use rusk_vm::{Contract, ContractId, GasMeter, NetworkState};
 use stack::Stack;
 
@@ -38,12 +37,11 @@ fn stack_bench(c: &mut Criterion) {
         ".wasm"
     ));
 
-    let store = StoreRef::new(HostStore::new());
-    let contract = Contract::new(&stack, code.to_vec(), &store);
+    let mut network = NetworkState::new();
 
-    let mut network = NetworkState::new(store);
-
+    let contract = Contract::new(&stack, code.to_vec(), network.store());
     let contract_id = network.deploy(contract).unwrap();
+
     let mut gas = GasMeter::with_limit(1_000_000_000_000);
     c.bench_function("stack 64", |b| {
         b.iter(|| {

--- a/rusk-uplink/src/definitions.rs
+++ b/rusk-uplink/src/definitions.rs
@@ -150,12 +150,6 @@ impl ContractState {
     }
 }
 
-pub trait HostModule {
-    fn execute(&self);
-
-    fn module_id(&self) -> ContractId;
-}
-
 // TODO, use borrowed bytes here?
 #[derive(Debug, Default)]
 pub struct ReturnValue {

--- a/rusk-uplink/src/framing.rs
+++ b/rusk-uplink/src/framing.rs
@@ -13,7 +13,7 @@ pub fn get_state_arg<S, P>(
     written_state: u32,
     written_data: u32,
     scratch: impl AsRef<[u8]>,
-    store: StoreContext,
+    mut store: StoreContext,
 ) -> (S, P)
 where
     S: Archive,
@@ -26,13 +26,13 @@ where
     let state = unsafe {
         archived_root::<S>(&scratch.as_ref()[..written_state as usize])
     };
-    let state: S = state.deserialize(&mut store.clone()).unwrap();
+    let state: S = state.deserialize(&mut store).unwrap();
     let arg = unsafe {
         archived_root::<P>(
             &scratch.as_ref()[written_state as usize..written_data as usize],
         )
     };
-    let arg: P = arg.deserialize(&mut store.clone()).unwrap();
+    let arg: P = arg.deserialize(&mut store).unwrap();
 
     (state, arg)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ mod resolver;
 mod state;
 
 pub use rusk_uplink;
-pub use state::persist::NetworkStateId;
 
 pub use config::{Config, HostCosts, OpCosts};
 pub use contract::{Contract, ContractId};

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -14,12 +14,17 @@ use crate::VMError;
 
 use cached::cached_key_result;
 use cached::TimedSizedCache;
-use rusk_uplink::HostModule;
 use thiserror::Error;
 use tracing::trace;
 use wasmer::Module;
 
 pub use rusk_uplink::{hash, ContractId, ContractState};
+
+pub trait HostModule {
+    fn execute(&self);
+
+    fn module_id(&self) -> ContractId;
+}
 
 type BoxedHostModule = Box<dyn HostModule>;
 

--- a/src/state/builder.rs
+++ b/src/state/builder.rs
@@ -1,0 +1,127 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::config::{Config, DEFAULT_CONFIG};
+use crate::contract::Contract;
+use crate::modules::{HostModule, HostModules};
+use crate::state::{Contracts, NetworkState};
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use dusk_hamt::Hamt;
+use microkelvin::{HostStore, Ident, OffsetLen};
+use rkyv::{archived_root, Archive, Deserialize, Infallible};
+use rusk_uplink::{ContractId, StoreContext};
+
+/// Builder for a [`NetworkState`].
+pub struct NetworkStateBuilder {
+    store_and_contracts: Option<(StoreContext, Contracts)>,
+    modules: HostModules,
+    id_path: Option<PathBuf>,
+    config: &'static Config,
+}
+
+impl NetworkStateBuilder {
+    const PERSISTENCE_ID_FILE_NAME: &'static str = "persist_id";
+
+    /// Create a new [`NetworkState`] builder.
+    pub fn new() -> Self {
+        NetworkStateBuilder::default()
+    }
+
+    /// Set the configuration for the network state.
+    pub fn config(self, config: &'static Config) -> Self {
+        Self {
+            store_and_contracts: self.store_and_contracts,
+            modules: self.modules,
+            id_path: self.id_path,
+            config,
+        }
+    }
+
+    /// Set the directory to store the state. If not set,
+    pub fn store_dir<P: AsRef<Path>>(self, dir: P) -> io::Result<Self> {
+        let dir = dir.as_ref();
+
+        let id_path = dir.join(Self::PERSISTENCE_ID_FILE_NAME);
+
+        let store = StoreContext::new(HostStore::with_file(dir)?);
+        let contracts = match id_path.exists() && id_path.is_file() {
+            true => {
+                let buf = fs::read(&id_path)?;
+                let persist_id =
+                    unsafe { archived_root::<OffsetLen>(buf.as_slice()) };
+                let persist_id =
+                    persist_id.deserialize(&mut Infallible).unwrap();
+
+                let contracts_ident = Ident::<
+                    Hamt<ContractId, Contract, (), OffsetLen>,
+                    OffsetLen,
+                >::new(persist_id);
+
+                let contracts: &<Hamt<ContractId, Contract, (), OffsetLen> as Archive>::Archived =
+                        store.get::<Hamt<ContractId, Contract, (), OffsetLen>>(&contracts_ident);
+
+                Contracts(contracts.deserialize(&mut store.clone()).unwrap())
+            }
+            false => Contracts::default(),
+        };
+
+        Ok(Self {
+            store_and_contracts: Some((store, contracts)),
+            modules: self.modules,
+            id_path: Some(id_path),
+            config: self.config,
+        })
+    }
+
+    /// Use the given host module.
+    pub fn module<M>(self, module: M) -> Self
+    where
+        M: 'static + HostModule,
+    {
+        let mut modules = self.modules;
+        modules.insert(module);
+
+        Self {
+            store_and_contracts: self.store_and_contracts,
+            modules,
+            id_path: self.id_path,
+            config: self.config,
+        }
+    }
+
+    /// Build the [`NetworkState`].
+    pub fn build(self) -> NetworkState {
+        let (store, contracts) =
+            self.store_and_contracts.unwrap_or_else(|| {
+                let store = StoreContext::new(HostStore::new());
+                let contracts = Contracts::default();
+                (store, contracts)
+            });
+
+        NetworkState {
+            contracts,
+            modules: self.modules,
+            store,
+            id_path: self.id_path,
+            config: self.config,
+        }
+    }
+}
+
+impl Default for NetworkStateBuilder {
+    fn default() -> Self {
+        Self {
+            store_and_contracts: None,
+            modules: HostModules::default(),
+            id_path: None,
+            config: &DEFAULT_CONFIG,
+        }
+    }
+}

--- a/src/state/persist.rs
+++ b/src/state/persist.rs
@@ -4,19 +4,13 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_hamt::Hamt;
-use microkelvin::{HostStore, Ident, OffsetLen, StoreRef};
 use rkyv::ser::{serializers::AllocSerializer, Serializer};
-use rkyv::{archived_root, Archive, Deserialize, Infallible, Serialize};
-use rusk_uplink::ContractId;
 use std::fs;
 use std::io;
-use std::path::Path;
 use thiserror::Error;
 
-use crate::contract::Contract;
-use crate::state::{Contracts, NetworkState};
-use crate::VMError;
+use crate::error::VMError;
+use crate::state::NetworkState;
 
 /// An error that can happen when persisting structures to disk
 #[derive(Error, Debug)]
@@ -29,103 +23,27 @@ pub enum PersistError {
     Store(String),
 }
 
-/// The [`NetworkStateId`] is the persisted id of the [`NetworkState`]
-#[derive(Archive, Serialize, Deserialize, Default, Clone, Debug)]
-pub struct NetworkStateId {
-    contracts: OffsetLen,
-}
-
-impl NetworkStateId {
-    /// Read from the given path a [`NetworkStateId`]
-    pub fn read<P: AsRef<Path>>(path: P) -> Result<Self, VMError> {
-        let buf = fs::read(&path).map_err(PersistError::Io)?;
-        let id = unsafe { archived_root::<NetworkStateId>(buf.as_slice()) };
-        let id: NetworkStateId = id.deserialize(&mut Infallible).unwrap();
-        Ok(id)
-    }
-
-    /// Write to the given path a [`NetworkStateId`]
-    pub fn write<P: AsRef<Path>>(&self, path: P) -> Result<(), VMError> {
-        let mut serializer = AllocSerializer::<0>::default();
-        serializer.serialize_value(self).unwrap();
-        let bytes = serializer.into_serializer().into_inner();
-        fs::write(&path, bytes.as_slice()).map_err(PersistError::Io)?;
-        Ok(())
-    }
-}
-
 impl NetworkState {
-    const PERSISTENCE_ID_FILE_NAME: &'static str = "persist_id";
-
-    /// Persists the origin contracts stored on the [`NetworkState`], together
-    /// with their configuration
-    pub fn persist(
-        &self,
-        store: StoreRef<OffsetLen>,
-    ) -> Result<NetworkStateId, VMError> {
+    /// Persists the contracts in the [`NetworkState`].
+    pub fn persist(&self) -> Result<(), VMError> {
+        let store = &self.store;
         let contracts_stored = store.store(&self.contracts.0);
         store.persist().map_err(|_| {
             PersistError::Store(String::from(
                 "Store persistence failed for network state",
             ))
         })?;
-        Ok(NetworkStateId {
-            contracts: *contracts_stored.ident().erase(),
-        })
-    }
 
-    /// Persists the state to disk along with persistence id
-    pub fn persist_to_disk<P: AsRef<Path>>(
-        &self,
-        store: StoreRef<OffsetLen>,
-        store_path: P,
-    ) -> Result<NetworkStateId, VMError> {
-        let persistence_id = self.persist(store)?;
+        if let Some(id_path) = &self.id_path {
+            let persistence_id = *contracts_stored.ident().erase();
 
-        let file_path =
-            store_path.as_ref().join(Self::PERSISTENCE_ID_FILE_NAME);
+            let mut serializer = AllocSerializer::<0>::default();
+            serializer.serialize_value(&persistence_id).unwrap();
+            let bytes = serializer.into_serializer().into_inner();
 
-        persistence_id.write(file_path)?;
+            fs::write(id_path, bytes).map_err(PersistError::Io)?;
+        }
 
-        Ok(persistence_id)
-    }
-
-    /// Given a [`NetworkStateId`] restores both [`Hamt`]s which store the
-    /// contract - the entire blockchain state - together with configuration.
-    pub fn restore(
-        mut self,
-        store: StoreRef<OffsetLen>,
-        id: NetworkStateId,
-    ) -> Result<Self, VMError> {
-        let contracts_ident = Ident::<
-            Hamt<ContractId, Contract, (), OffsetLen>,
-            OffsetLen,
-        >::new(id.contracts);
-
-        let restored_contracts: &<Hamt<ContractId, Contract, (), OffsetLen> as Archive>::Archived =
-            store.get::<Hamt<ContractId, Contract, (), OffsetLen>>(&contracts_ident);
-
-        let restored_contracts: Hamt<ContractId, Contract, (), OffsetLen> =
-            restored_contracts.deserialize(&mut store.clone()).unwrap();
-
-        self.contracts = Contracts(restored_contracts);
-
-        Ok(self)
-    }
-
-    /// Restores network state
-    /// given source disk path.
-    pub fn restore_from_disk<P: AsRef<Path>>(
-        source_store_path: P,
-    ) -> Result<Self, VMError> {
-        let store = StoreRef::new(
-            HostStore::with_file(source_store_path.as_ref())
-                .map_err(PersistError::Io)?,
-        );
-        let file_path = source_store_path
-            .as_ref()
-            .join(Self::PERSISTENCE_ID_FILE_NAME);
-        let persistence_id = NetworkStateId::read(file_path)?;
-        NetworkState::new(store.clone()).restore(store, persistence_id)
+        Ok(())
     }
 }

--- a/tests/gas_usage.rs
+++ b/tests/gas_usage.rs
@@ -6,21 +6,18 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use counter::Counter;
-use microkelvin::{HostStore, StoreRef};
 use register::*;
 use rusk_vm::{Contract, GasMeter, NetworkState};
 use stack::*;
 
 fn execute_counter_contract() -> u64 {
-    let counter = Counter::new(99);
+    let mut network = NetworkState::new();
 
+    let counter = Counter::new(99);
     let code =
         include_bytes!("../target/wasm32-unknown-unknown/release/counter.wasm");
 
-    let store = StoreRef::new(HostStore::new());
-    let contract = Contract::new(&counter, code.to_vec(), &store);
-    let mut network = NetworkState::new(store);
-
+    let contract = Contract::new(&counter, code.to_vec(), network.store());
     let contract_id = network.deploy(contract).expect("Deploy error");
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
@@ -37,14 +34,13 @@ fn execute_counter_contract() -> u64 {
 }
 
 fn execute_stack_single_push_pop_contract() -> u64 {
+    let mut network = NetworkState::new();
+
     let code =
         include_bytes!("../target/wasm32-unknown-unknown/release/stack.wasm");
     let stack = Stack::new();
 
-    let store = StoreRef::new(HostStore::new());
-    let contract = Contract::new(&stack, code.to_vec(), &store);
-    let mut network = NetworkState::new(store);
-
+    let contract = Contract::new(&stack, code.to_vec(), network.store());
     let contract_id = network.deploy(contract).expect("Deploy error");
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
@@ -61,14 +57,13 @@ fn execute_stack_single_push_pop_contract() -> u64 {
 }
 
 fn execute_stack_multi_push_pop_contract(count: u64) -> u64 {
+    let mut network = NetworkState::new();
+
     let code =
         include_bytes!("../target/wasm32-unknown-unknown/release/stack.wasm");
     let stack = Stack::new();
 
-    let store = StoreRef::new(HostStore::new());
-    let contract = Contract::new(&stack, code.to_vec(), &store);
-    let mut network = NetworkState::new(store);
-
+    let contract = Contract::new(&stack, code.to_vec(), network.store());
     let contract_id = network.deploy(contract).expect("Deploy error");
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
@@ -85,14 +80,13 @@ fn execute_stack_multi_push_pop_contract(count: u64) -> u64 {
 }
 
 fn execute_multiple_transactions_stack_contract(count: u64) -> u64 {
+    let mut network = NetworkState::new();
+
     let code =
         include_bytes!("../target/wasm32-unknown-unknown/release/stack.wasm");
     let stack = Stack::new();
 
-    let store = StoreRef::new(HostStore::new());
-    let contract = Contract::new(&stack, code.to_vec(), &store);
-    let mut network = NetworkState::new(store);
-
+    let contract = Contract::new(&stack, code.to_vec(), network.store());
     let contract_id = network.deploy(contract).expect("Deploy error");
 
     let mut gas = GasMeter::with_limit(1_000_000_000);
@@ -108,15 +102,14 @@ fn execute_multiple_transactions_stack_contract(count: u64) -> u64 {
 }
 
 fn execute_multiple_register_contract(count: u64) -> u64 {
+    let mut network = NetworkState::new();
+
     let code = include_bytes!(
         "../target/wasm32-unknown-unknown/release/register.wasm"
     );
     let register = Register::new();
 
-    let store = StoreRef::new(HostStore::new());
-    let contract = Contract::new(&register, code.to_vec(), &store);
-    let mut network = NetworkState::new(store);
-
+    let contract = Contract::new(&register, code.to_vec(), network.store());
     let contract_id = network.deploy(contract).expect("Deploy error");
 
     let mut gas = GasMeter::with_limit(1_000_000_000);


### PR DESCRIPTION
This changes the instantiation and persistence mechanism of a `NetworkState` by adding a builder. This has the rather pleasant consequence that the user doesn't need to keep store references, with the notable exception of add-hoc instantiating and adding contracts to the state.

Resolves #319 